### PR TITLE
Fix google GitHub actions

### DIFF
--- a/push-to-gcr/action.yml
+++ b/push-to-gcr/action.yml
@@ -39,7 +39,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         clean: false
 

--- a/push-to-gcr/action.yml
+++ b/push-to-gcr/action.yml
@@ -51,12 +51,12 @@ runs:
         pattern: ${{ github.repository_owner }}/
         replace-with: ''
 
-    # Setup gcloud CLI
-    - uses: google-github-actions/setup-gcloud@master
+    - uses: google-github-actions/auth@v0
       with:
-        version: '270.0.0'
-        service_account_email: ${{ inputs.google-email }}
-        service_account_key: ${{ inputs.google-key }}
+        credentials_json: ${{ inputs.google-key }}
+
+    # Setup gcloud CLI
+    - uses: google-github-actions/setup-gcloud@v0
 
     # Configure docker to use the gcloud command-line tool as a credential helper
     - run: gcloud auth configure-docker


### PR DESCRIPTION
Pins the `gcloud-setup` action to v0 instead of master. Additionally moved authentication to its sibling `auth` action to address the [deprecation](https://github.com/google-github-actions/setup-gcloud#authentication-inputs).

Bumped checkout to v3 while at it.