### PR TITLE
Change push to artifactory action for other repos

### DIFF
--- a/push-to-artifactory/action.yml
+++ b/push-to-artifactory/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'Path to the docker context'
     required: false
     default: .
+  file:
+    description: 'Path to Dockerfile'
+    required: false
+    default: Dockerfile
   name-suffix:
     description: 'name suffix to be added to image name'
     required: false
@@ -63,12 +67,10 @@ runs:
         tags: |
           type=sha,enable=true,priority=100,prefix=${{ inputs.name-suffix }},suffix=,format=short
 
-    - name: Build and push
-      id: docker_build
-      uses: docker/build-push-action@v2
+    - uses: docker/build-push-action@v2
       with:
         context: ${{ inputs.context }}
-        file: ${{ inputs.service-name }}/Dockerfile
+        file: ${{ inputs.file }}
         builder: ${{ steps.buildx.outputs.name }}
         push: true
         tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
For other repos, the structure is different for main repo..so giving an option to provide dockerfile, if not given that will work with servicename/Dockerfile.
