### PR TITLE
Fix: Pass token to cherry-pick action

### DIFF
--- a/cherry-pick-pr/action.yml
+++ b/cherry-pick-pr/action.yml
@@ -136,12 +136,11 @@ runs:
       id: cherry-pick
       uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
       with:
+        token: ${{ inputs.github-token }}
         branch: ${{ inputs.target-branch }}
         cherry-pick-branch: ${{ inputs.cherry-pick-branch-prefix }}${{ github.event.pull_request.head.ref }}
         body: ${{ inputs.cherry-pick-pr-body }}
         labels: ${{ inputs.labels }}
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
 
     - name: Set output status
       id: set-status


### PR DESCRIPTION
Fixes workflows not triggering for cherry-pick PRs.

**Root cause:** Token was set as environment variable but carloscastrojumo/github-cherry-pick-action expects it as input parameter. When not provided, it defaults to github.token which doesn't trigger workflows.

**Fix:** Pass token as input parameter to the action.