### PR TITLE
fix: YAML parse error in ai-review action

### DIFF
--- a/ai-review/action.yml
+++ b/ai-review/action.yml
@@ -1,5 +1,5 @@
 name: 'AI Code Review'
-description: 'AI code review on pull requests using Claude — inline, incremental, deduplicated, Tilda-specific'
+description: 'AI code review on pull requests using Claude — CRITICAL issues only, inline comments, incremental on sync'
 author: 'Tilda Bio'
 
 inputs:
@@ -23,10 +23,6 @@ inputs:
     description: 'Maximum diff size in characters (to control token usage)'
     required: false
     default: '100000'
-  max-comments:
-    description: 'Maximum inline comments per review'
-    required: false
-    default: '5'
   context-file:
     description: 'Path to a repo-specific context file (e.g. .github/AI_CONTEXT.md). Requires checkout.'
     required: false
@@ -45,7 +41,7 @@ outputs:
     description: 'Status of the review (success, skipped, error)'
     value: ${{ steps.run-review.outputs.review_status }}
   comments-posted:
-    description: 'Number of inline comments posted'
+    description: 'Number of comments posted'
     value: ${{ steps.run-review.outputs.comments_posted }}
 
 runs:
@@ -66,7 +62,6 @@ runs:
         REPOSITORY: ${{ inputs.repository }}
         MODEL: ${{ inputs.model }}
         MAX_DIFF_SIZE: ${{ inputs.max-diff-size }}
-        MAX_COMMENTS: ${{ inputs.max-comments }}
         CONTEXT_FILE: ${{ inputs.context-file }}
         CUSTOM_PROMPT: ${{ inputs.custom-prompt }}
         BOT_USERNAME: ${{ inputs.bot-username }}
@@ -85,13 +80,10 @@ runs:
         REPOSITORY     = os.environ["REPOSITORY"]
         MODEL          = os.environ["MODEL"]
         MAX_DIFF_SIZE  = int(os.environ["MAX_DIFF_SIZE"])
-        MAX_COMMENTS   = int(os.environ["MAX_COMMENTS"])
         CONTEXT_FILE   = os.environ.get("CONTEXT_FILE", "")
         CUSTOM_PROMPT  = os.environ.get("CUSTOM_PROMPT", "")
         BOT_USERNAME   = os.environ.get("BOT_USERNAME", "ojasgo")
         ANTHROPIC_KEY  = os.environ["ANTHROPIC_API_KEY"]
-
-        SEVERITY_RANK = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3}
 
         def gh(*args):
             r = subprocess.run(["gh"] + list(args), capture_output=True, text=True, timeout=120)
@@ -115,29 +107,37 @@ runs:
         head_sha    = commits[-1]["oid"] if commits else ""
         print(f"  {head_branch} -> {base_branch} ({len(commits)} commits, HEAD {head_sha[:8]})")
 
-        # ─── 2. Incremental: find last AI review commit ──────────────────
+        # ─── 2. Check for previous AI review ─────────────────────────────
         print("Checking for previous AI reviews...")
-        raw = gh("api", f"repos/{REPOSITORY}/pulls/{PR_NUMBER}/reviews", "--paginate")
-        reviews = json.loads(raw) if raw else []
+        raw = gh("api", f"repos/{REPOSITORY}/pulls/{PR_NUMBER}/comments", "--paginate")
+        existing_comments = json.loads(raw) if raw else []
 
-        last_sha = None
-        for rev in reversed(reviews):
-            if (rev.get("user", {}).get("login") == BOT_USERNAME
-                    and "AI Code Review" in (rev.get("body") or "")):
-                last_sha = rev.get("commit_id")
-                break
+        # Find last reviewed commit from bot comments
+        last_reviewed_sha = None
+        seen_lines = set()
+        for c in existing_comments:
+            if c.get("user", {}).get("login") == BOT_USERNAME:
+                cid = c.get("commit_id")
+                if cid:
+                    last_reviewed_sha = cid
+                seen_lines.add(f"{c.get('path','')}:{c.get('line') or c.get('original_line') or 0}")
+
+        print(f"  {len(seen_lines)} existing bot comments, last reviewed: {last_reviewed_sha[:8] if last_reviewed_sha else 'none'}")
 
         # ─── 3. Get diff ─────────────────────────────────────────────────
         incremental = False
-        if last_sha:
-            print(f"  Previous review at {last_sha[:8]}. Diffing incremental...")
-            diff = gh("api", f"repos/{REPOSITORY}/compare/{last_sha}...{head_sha}",
+        if last_reviewed_sha and last_reviewed_sha != head_sha:
+            print(f"  Incremental diff: {last_reviewed_sha[:8]}..{head_sha[:8]}")
+            diff = gh("api", f"repos/{REPOSITORY}/compare/{last_reviewed_sha}...{head_sha}",
                       "--jq", '.files[]? | "diff --git a/" + .filename + " b/" + .filename + "\\n" + (.patch // "")')
             if diff:
                 incremental = True
             else:
                 print("  No new changes since last review. Skipping.")
                 out("review_status", "skipped"); out("comments_posted", "0"); sys.exit(0)
+        elif last_reviewed_sha == head_sha:
+            print("  Already reviewed this commit. Skipping.")
+            out("review_status", "skipped"); out("comments_posted", "0"); sys.exit(0)
         else:
             print("  First review — full PR diff.")
             diff = gh("pr", "diff", PR_NUMBER, "--repo", REPOSITORY)
@@ -149,113 +149,63 @@ runs:
         if len(diff) > MAX_DIFF_SIZE:
             diff = diff[:MAX_DIFF_SIZE] + "\n\n... [DIFF TRUNCATED] ..."
 
-        # ─── 4. Existing comments for dedup ───────────────────────────────
-        raw = gh("api", f"repos/{REPOSITORY}/pulls/{PR_NUMBER}/comments", "--paginate")
-        existing = json.loads(raw) if raw else []
-        seen = set()
-        for c in existing:
-            if c.get("user", {}).get("login") == BOT_USERNAME:
-                seen.add(f"{c.get('path','')}:{c.get('line') or c.get('original_line') or 0}")
-        print(f"  {len(seen)} existing bot comments for dedup")
-
-        # ─── 5. Read repo context file ────────────────────────────────────
+        # ─── 4. Read repo context file ────────────────────────────────────
         repo_context = ""
         if CONTEXT_FILE and os.path.isfile(CONTEXT_FILE):
             with open(CONTEXT_FILE) as f:
                 repo_context = f.read()
             print(f"  Loaded context from {CONTEXT_FILE} ({len(repo_context)} chars)")
 
-        # ─── 6. Build prompt ──────────────────────────────────────────────
-        # System prompt = REVIEW.md guidelines (Tilda-specific)
-        system_prompt = textwrap.dedent(f"""\
-            You are a code review agent for Tilda, a biotech platform.
+        # ─── 5. Build prompt ──────────────────────────────────────────────
+        system_prompt = textwrap.dedent("""\
+            You are a senior code reviewer. You ONLY report CRITICAL issues — bugs, security vulnerabilities, data loss, and crashes that MUST be fixed before merge.
 
-            RULES — read these first:
-            - Signal > volume. If unsure whether something is a real issue, do NOT comment.
-            - Report ALL CRITICAL issues — no limit. For HIGH/MEDIUM, limit to {MAX_COMMENTS} comments. Prioritize highest impact.
-            - If a CRITICAL issue exists, report it first. Continue reviewing for other CRITICAL issues but skip non-critical observations.
+            RULES:
+            - ONLY comment on issues that will cause bugs, security holes, data loss, or crashes in production.
+            - Do NOT comment on style, naming, formatting, missing docs, type hints, or import ordering.
+            - Do NOT suggest alternatives, improvements, or "consider doing X".
+            - Do NOT comment on things that require full codebase context to verify.
+            - Do NOT nitpick. If you are not 90%+ confident it is a real production issue, do NOT comment.
+            - If no critical issues: return {"comments": []}
             - Return ONLY valid JSON. No markdown fences, no explanation outside JSON.
-            - Each comment: file path + line number (from ADDED side, calculated from @@ hunk headers) + 1-4 line body with concrete fix.
-            - Severity tags: [CRITICAL] must fix before merge, [HIGH] strongly recommended, [MEDIUM] improvement.
-            - Do NOT use [LOW]. If it is not materially impactful, do not comment.
-            - If no issues: return {{"summary": "LGTM", "comments": []}}
-            - No summary paragraph. No praise. Only findings.
 
-            REPOSITORY CONTEXT:
-            This is a monorepo with:
-            - ~18 Go microservices (execsvc, docsvc, patientsvc, schedsvc, enrollsvc, studiosvc, finsvc, notifsvc, dslsvc, authz, dashQL, dashRsvc, regsvc, advpsvc, workplansvc, datasvc, payoutsvc, tusker)
-            - Shared Go libraries (common/, tildadb/, tildaobj/, api/, tlang/, util/) — changes here affect many services
-            - Python AI services under data-science/ (studioai, virtual_assistant, docproc, exportsvc) — LangChain, OpenAI, Neo4j, PubSub
-            - Neo4j as primary database with Cypher queries
-            - Google Cloud Pub/Sub for async messaging (at-least-once delivery — consumers must be idempotent)
-            - GraphQL (gqlgen) in dashQL
-            - GitHub Actions CI/CD
+            WHAT IS CRITICAL:
+            - Hardcoded secrets/passwords/API keys
+            - Injection vulnerabilities (SQL, Cypher, command, prompt)
+            - Silent exception swallowing on critical paths (data loss)
+            - Command injection via shell=True or os.system with user input
+            - Missing timeout on external calls (can hang forever)
+            - PubSub messages ACKed before processing (data loss)
+            - Removed safety checks (validation, bounds, cleanup) without replacement
+            - Race conditions that cause data corruption
+            - Breaking changes to shared libraries without downstream updates
 
-            PR NECESSITY CHECK (do first):
-            - Is this PR necessary? Could the goal be achieved simpler?
-            - Does the diff include unrelated changes? Unnecessary abstractions?
-            - Flag over-engineering before reviewing code details.
-
-            WHAT TO CHECK:
-
-            1. Correctness: Logic errors, null dereferences, wrong variable, off-by-one, incorrect control flow
-            2. Security: Hardcoded secrets, injection (SQL, Cypher, command, prompt), missing auth, PHI/PII exposure, insecure crypto
-            3. Concurrency: Goroutines without context cancellation, unsafe concurrent map access, race conditions, blocking calls in goroutines
-            4. Distributed reliability: Non-idempotent retries, at-least-once vs exactly-once confusion, missing partial failure handling, PubSub ack/nack errors silently swallowed
-            5. Error handling: Silent except/pass, missing error handling on DB/API/message paths, ignored Go error returns, panics in production
-            6. Data integrity: Messages dropped, partial writes without rollback, state corruption, Neo4j session/transaction not closed
-            7. Breaking changes: Shared library changes without downstream consideration, API contract changes, schema changes breaking rolling deploys, removed fields callers depend on
-            8. Performance: N+1 Cypher queries in loops, unbounded memory, missing pagination, full graph scans
-            9. Cross-service impact: Changes to common/, tildaobj/, tildadb/ affect all services — increase severity by one level for shared code changes
-
-            GO-SPECIFIC:
-            - Missing or ignored error returns
-            - Goroutines without context cancellation
-            - Unsafe concurrent map access
-            - Panics in production paths
-            - Neo4j session/transaction not closed
-            - Cypher injection via string concatenation (must use parameterized queries)
-            - Missing timeout on external calls
-
-            PYTHON-SPECIFIC:
-            - Blocking I/O inside async code
-            - Silent exception swallowing (bare except/pass on critical paths)
-            - User input concatenated into LLM prompts
-            - LLM responses used without validation
-            - Unbounded agent loops (missing max iterations)
-            - Missing resource cleanup
-
-            NEO4J/CYPHER:
-            - Non-existent node labels or relationship types (verify against tildaobj/ if visible)
-            - Relationships traversed in wrong direction
-            - String concatenation instead of parameterized queries
-            - Queries causing full graph scans (missing WHERE clause on indexed property)
-
-            WHAT NOT TO CHECK:
-            - Formatting, naming, import ordering, type hints
-            - Missing docstrings or comments
-            - "Consider using X instead of Y" suggestions
-            - Hypothetical issues requiring full codebase context to verify
-            - Non-critical optimizations
-            - Alternative architectures
+            WHAT IS NOT CRITICAL (do NOT comment):
+            - Code style, naming conventions, formatting
+            - Missing error logging (unless it hides data loss)
+            - "Consider using X" suggestions
+            - Hypothetical issues
+            - Performance unless it causes OOM or timeout
+            - Missing tests
+            - Import ordering, unused imports
+            - Commented-out code
 
             Response format:
-            {{
+            {
               "comments": [
-                {{"path": "file.go", "line": 42, "body": "[CRITICAL] Description. Fix: ..."}}
+                {"path": "file.go", "line": 42, "body": "Description of the critical issue and how to fix it."}
               ]
-            }}""")
+            }""")
 
-        # Append repo-specific context if available
         if repo_context:
-            system_prompt += "\n\nADDITIONAL REPO CONTEXT:\n" + repo_context
+            system_prompt += "\n\nREPO CONTEXT:\n" + repo_context
 
         if CUSTOM_PROMPT:
             system_prompt += "\n\nADDITIONAL INSTRUCTIONS:\n" + CUSTOM_PROMPT
 
         label = "incremental (new commits only)" if incremental else "full PR"
         user_prompt = textwrap.dedent(f"""\
-            Review this {label} diff. Return JSON only.
+            Review this {label} diff. Return JSON only. Only CRITICAL issues.
 
             Title: {pr_title}
             Description: {pr_body}
@@ -266,7 +216,7 @@ runs:
             {diff}
             ```""")
 
-        # ─── 7. Call Claude ───────────────────────────────────────────────
+        # ─── 6. Call Claude ───────────────────────────────────────────────
         print(f"Calling Claude ({MODEL})...")
         payload = {
             "model": MODEL,
@@ -312,105 +262,55 @@ runs:
         comments = review.get("comments", [])
         print(f"  Claude returned {len(comments)} comment(s)")
 
-        # ─── 8. Filter: dedup, severity, cap ──────────────────────────────
-        filtered = []
-        skip_sev = 0
-        skip_dup = 0
-
+        # ─── 7. Dedup against existing bot comments ──────────────────────
+        final = []
         for c in comments:
-            body = c.get("body", "")
             path = c.get("path", "")
             line = c.get("line", 0)
+            if f"{path}:{line}" in seen_lines:
+                print(f"  Skipping duplicate: {path}:{line}")
+                continue
+            final.append(c)
 
-            sev = "MEDIUM"
-            for s in SEVERITY_RANK:
-                if f"[{s}]" in body:
-                    sev = s; break
-
-            # Drop LOW
-            if SEVERITY_RANK.get(sev, 3) > 2:
-                skip_sev += 1; continue
-
-            # Dedup
-            if f"{path}:{line}" in seen:
-                skip_dup += 1; continue
-
-            filtered.append({"path": path, "line": line, "body": body, "_sev": sev})
-
-        filtered.sort(key=lambda x: SEVERITY_RANK.get(x["_sev"], 3))
-
-        # All CRITICALs always go through, cap only applies to HIGH/MEDIUM
-        criticals = [c for c in filtered if c["_sev"] == "CRITICAL"]
-        non_criticals = [c for c in filtered if c["_sev"] != "CRITICAL"]
-        capped_non_criticals = non_criticals[:MAX_COMMENTS]
-        final = criticals + capped_non_criticals
-        skipped_cap = max(0, len(non_criticals) - MAX_COMMENTS)
-
-        print(f"  Posting {len(final)} ({len(criticals)} CRITICAL uncapped + {len(capped_non_criticals)} HIGH/MEDIUM, skipped: {skip_sev} low-severity, {skip_dup} duplicates, {skipped_cap} over cap)")
-
-        # ─── 9. Post review ──────────────────────────────────────────────
-        label = "incremental" if incremental else "full"
-        sev_counts = {}
-        for c in final:
-            s = c["_sev"]; sev_counts[s] = sev_counts.get(s, 0) + 1
-        sev_line = ", ".join(f"{v} {k}" for k, v in sorted(sev_counts.items(), key=lambda x: SEVERITY_RANK.get(x[0], 3)))
-
-        body_text = f"## AI Code Review ({label})"
-        if sev_line:
-            body_text += f"\n\n{sev_line}"
-        if skip_dup:
-            body_text += f"\n\n_{skip_dup} duplicate(s) skipped_"
-        body_text += "\n\n---\n*Powered by Claude*"
+        print(f"  {len(final)} new comment(s) after dedup")
 
         if not final:
-            f = "/tmp/ai_review_lgtm.md"
-            with open(f, "w") as fh:
-                fh.write(f"## AI Code Review ({label})\n\nLGTM — no critical issues found.\n\n---\n*Powered by Claude*")
-            gh("pr", "comment", PR_NUMBER, "--repo", REPOSITORY, "--body-file", f)
-            print("  Posted LGTM")
+            print("  No critical issues found.")
             out("review_status", "success"); out("comments_posted", "0"); sys.exit(0)
 
-        # Try batch post
-        payload = {
-            "commit_id": head_sha,
-            "body": body_text,
-            "event": "COMMENT",
-            "comments": [{"path": c["path"], "line": c["line"], "side": "RIGHT", "body": c["body"]} for c in final]
-        }
-        pf = "/tmp/ai_review_payload.json"
-        with open(pf, "w") as f:
-            json.dump(payload, f)
-
-        r = subprocess.run(
-            ["gh", "api", "--method", "POST", "-H", "Accept: application/vnd.github+json",
-             f"repos/{REPOSITORY}/pulls/{PR_NUMBER}/reviews", "--input", pf],
-            capture_output=True, text=True, timeout=60
-        )
-
-        if r.returncode == 0:
-            print(f"  Posted {len(final)} inline comment(s)")
-            out("review_status", "success"); out("comments_posted", str(len(final))); sys.exit(0)
-
-        # Batch failed — post one by one, skip line mismatches
-        print(f"  Batch failed, posting individually...")
+        # ─── 8. Post as individual line comments (not review threads) ────
+        # Using pull request comments API (not reviews API) so comments
+        # don't create "conversations" that block merging.
         posted = 0
-        for i, c in enumerate(final):
-            sp = {"commit_id": head_sha, "body": body_text if i == 0 else "", "event": "COMMENT",
-                  "comments": [{"path": c["path"], "line": c["line"], "side": "RIGHT", "body": c["body"]}]}
-            sf = f"/tmp/ai_review_{i}.json"
-            with open(sf, "w") as f:
-                json.dump(sp, f)
-            sr = subprocess.run(
+        for c in final:
+            path = c.get("path", "")
+            line = c.get("line", 0)
+            body = c.get("body", "")
+
+            comment_payload = {
+                "body": body,
+                "commit_id": head_sha,
+                "path": path,
+                "line": line,
+                "side": "RIGHT"
+            }
+            cf = f"/tmp/ai_comment_{posted}.json"
+            with open(cf, "w") as f:
+                json.dump(comment_payload, f)
+
+            r = subprocess.run(
                 ["gh", "api", "--method", "POST", "-H", "Accept: application/vnd.github+json",
-                 f"repos/{REPOSITORY}/pulls/{PR_NUMBER}/reviews", "--input", sf],
+                 f"repos/{REPOSITORY}/pulls/{PR_NUMBER}/comments", "--input", cf],
                 capture_output=True, text=True, timeout=30
             )
-            if sr.returncode == 0:
-                posted += 1
-            else:
-                print(f"    Skipped {c['path']}:{c['line']} (line not in diff)")
 
-        print(f"  Posted {posted}/{len(final)}")
+            if r.returncode == 0:
+                posted += 1
+                print(f"  Posted: {path}:{line}")
+            else:
+                print(f"  Failed: {path}:{line} — {r.stderr[:200]}")
+
+        print(f"  Posted {posted}/{len(final)} comments")
         out("review_status", "success"); out("comments_posted", str(posted))
 
         PYEOF

--- a/ai-review/action.yml
+++ b/ai-review/action.yml
@@ -191,12 +191,23 @@ runs:
             - Import ordering, unused imports
             - Commented-out code
 
-            Response format:
+            Response format — each comment MUST have these 4 fields:
             {
               "comments": [
-                {"path": "file.go", "line": 42, "body": "Description of the critical issue and how to fix it."}
+                {
+                  "path": "src/api/helpers.py",
+                  "line": 42,
+                  "category": "Security|Data Loss|Reliability|Injection|Credentials",
+                  "body": "One sentence describing the problem. Keep it under 20 words."
+                }
               ]
-            }""")
+            }
+
+            IMPORTANT:
+            - "category" must be one of: Security, Data Loss, Reliability, Injection, Credentials
+            - "body" must be ONE short sentence — the problem only, no fix suggestion, no preamble
+            - Do NOT prefix body with "CRITICAL:" or any label — the category field handles that
+            - Do NOT write paragraphs — one sentence max""")
 
         if repo_context:
             system_prompt += "\n\nREPO CONTEXT:\n" + repo_context
@@ -274,30 +285,49 @@ runs:
             gh("pr", "comment", PR_NUMBER, "--repo", REPOSITORY, "--body-file", cf)
             out("review_status", "success"); out("comments_posted", "0"); sys.exit(0)
 
+        # Category emoji mapping
+        CAT_EMOJI = {
+            "security": "\U0001f6e1\ufe0f",
+            "injection": "\U0001f489",
+            "credentials": "\U0001f511",
+            "data loss": "\U0001f4a5",
+            "reliability": "\u26a0\ufe0f",
+        }
+
+        def fmt_category(cat):
+            key = (cat or "").lower()
+            emoji = CAT_EMOJI.get(key, "\U0001f534")
+            return f"{emoji} {cat}"
+
         # Build inline review comments for the diff
         review_comments = []
         for c in comments:
             path = c.get("path", "")
             line_num = c.get("line", 0)
             body = c.get("body", "")
+            cat = c.get("category", "Security")
             if path and line_num and body:
+                inline_body = f"{fmt_category(cat)}\n\n{body}"
                 review_comments.append({
                     "path": path,
                     "line": int(line_num),
                     "side": "RIGHT",
-                    "body": f"**CRITICAL:** {body}"
+                    "body": inline_body
                 })
 
         # Build formatted summary for the review body
         label = "new changes only" if incremental else "full diff"
         summary_lines = [f"## AI Code Review ({label})\n"]
         summary_lines.append(f"Found **{len(comments)}** critical issue(s):\n")
+        summary_lines.append("| | File | Issue |")
+        summary_lines.append("|---|---|---|")
         for i, c in enumerate(comments, 1):
             path = c.get("path", "")
             line_num = c.get("line", 0)
-            body = c.get("body", "")
-            summary_lines.append(f"**{i}.** [`{path}:{line_num}`](https://github.com/{REPOSITORY}/pull/{PR_NUMBER}/files#diff-{path})")
-            summary_lines.append(f"> {body}\n")
+            body = c.get("body", "").replace("|", "\\|")
+            cat = c.get("category", "Security")
+            short_path = path.split("/")[-1] if "/" in path else path
+            summary_lines.append(f"| {fmt_category(cat)} | `{short_path}:{line_num}` | {body} |")
         summary_body = "\n".join(summary_lines)
 
         # Submit PR review with inline comments + summary body

--- a/ai-review/action.yml
+++ b/ai-review/action.yml
@@ -278,40 +278,24 @@ runs:
             print("  No critical issues found.")
             out("review_status", "success"); out("comments_posted", "0"); sys.exit(0)
 
-        # ─── 8. Post as individual line comments (not review threads) ────
-        # Using pull request comments API (not reviews API) so comments
-        # don't create "conversations" that block merging.
-        posted = 0
-        for c in final:
+        # ─── 8. Post single formatted PR comment ─────────────────────────
+        # Single issue comment (not review/inline) — no threads to resolve.
+        lines = ["## :rotating_light: AI Code Review\n"]
+        for i, c in enumerate(final, 1):
             path = c.get("path", "")
             line = c.get("line", 0)
             body = c.get("body", "")
+            lines.append(f"### {i}. `{path}:{line}`")
+            lines.append(f"{body}\n")
 
-            comment_payload = {
-                "body": body,
-                "commit_id": head_sha,
-                "path": path,
-                "line": line,
-                "side": "RIGHT"
-            }
-            cf = f"/tmp/ai_comment_{posted}.json"
-            with open(cf, "w") as f:
-                json.dump(comment_payload, f)
+        comment_body = "\n".join(lines)
+        cf = "/tmp/ai_review_comment.md"
+        with open(cf, "w") as f:
+            f.write(comment_body)
 
-            r = subprocess.run(
-                ["gh", "api", "--method", "POST", "-H", "Accept: application/vnd.github+json",
-                 f"repos/{REPOSITORY}/pulls/{PR_NUMBER}/comments", "--input", cf],
-                capture_output=True, text=True, timeout=30
-            )
-
-            if r.returncode == 0:
-                posted += 1
-                print(f"  Posted: {path}:{line}")
-            else:
-                print(f"  Failed: {path}:{line} — {r.stderr[:200]}")
-
-        print(f"  Posted {posted}/{len(final)} comments")
-        out("review_status", "success"); out("comments_posted", str(posted))
+        gh("pr", "comment", PR_NUMBER, "--repo", REPOSITORY, "--body-file", cf)
+        print(f"  Posted single comment with {len(final)} finding(s)")
+        out("review_status", "success"); out("comments_posted", str(len(final)))
 
         PYEOF
 

--- a/ai-review/action.yml
+++ b/ai-review/action.yml
@@ -1,5 +1,5 @@
 name: 'AI Code Review'
-description: 'AI code review on pull requests using Claude — CRITICAL issues only, inline comments, incremental on sync'
+description: 'AI code review on pull requests using Claude — policy-driven via repo REVIEW.md, inline comments, incremental on sync'
 author: 'Tilda Bio'
 
 inputs:
@@ -24,11 +24,10 @@ inputs:
     required: false
     default: '100000'
   context-file:
-    description: 'Path to a repo-specific context file (e.g. .github/AI_CONTEXT.md). Requires checkout.'
-    required: false
-    default: ''
-  custom-prompt:
-    description: 'Additional instructions appended to the review prompt'
+    description: 'Path to repo REVIEW.md that defines review policy (severities, categories, rules). Requires checkout.'
+    required: true
+  repo-context:
+    description: 'Path to repo context file (e.g. AI_CONTEXT.md) with architecture details. Requires checkout.'
     required: false
     default: ''
   bot-username:
@@ -63,7 +62,7 @@ runs:
         MODEL: ${{ inputs.model }}
         MAX_DIFF_SIZE: ${{ inputs.max-diff-size }}
         CONTEXT_FILE: ${{ inputs.context-file }}
-        CUSTOM_PROMPT: ${{ inputs.custom-prompt }}
+        REPO_CONTEXT: ${{ inputs.repo-context }}
         BOT_USERNAME: ${{ inputs.bot-username }}
       run: |
         python3 << 'PYEOF'
@@ -80,8 +79,8 @@ runs:
         REPOSITORY     = os.environ["REPOSITORY"]
         MODEL          = os.environ["MODEL"]
         MAX_DIFF_SIZE  = int(os.environ["MAX_DIFF_SIZE"])
-        CONTEXT_FILE   = os.environ.get("CONTEXT_FILE", "")
-        CUSTOM_PROMPT  = os.environ.get("CUSTOM_PROMPT", "")
+        CONTEXT_FILE   = os.environ["CONTEXT_FILE"]
+        REPO_CONTEXT   = os.environ.get("REPO_CONTEXT", "")
         BOT_USERNAME   = os.environ.get("BOT_USERNAME", "ojasgo")
         ANTHROPIC_KEY  = os.environ["ANTHROPIC_API_KEY"]
 
@@ -150,74 +149,53 @@ runs:
         if len(diff) > MAX_DIFF_SIZE:
             diff = diff[:MAX_DIFF_SIZE] + "\n\n... [DIFF TRUNCATED] ..."
 
-        # ─── 4. Read repo context file ────────────────────────────────────
-        repo_context = ""
-        if CONTEXT_FILE and os.path.isfile(CONTEXT_FILE):
-            with open(CONTEXT_FILE) as f:
-                repo_context = f.read()
-            print(f"  Loaded context from {CONTEXT_FILE} ({len(repo_context)} chars)")
+        # ─── 4. Read REVIEW.md ──────────────────────────────────────────
+        if not CONTEXT_FILE or not os.path.isfile(CONTEXT_FILE):
+            print(f"::error::context-file not found: '{CONTEXT_FILE}'. Each repo must provide a REVIEW.md.")
+            out("review_status", "error"); out("comments_posted", "0"); sys.exit(1)
+
+        with open(CONTEXT_FILE) as f:
+            review_policy = f.read()
+        print(f"  Loaded review policy from {CONTEXT_FILE} ({len(review_policy)} chars)")
+
+        repo_architecture = ""
+        if REPO_CONTEXT and os.path.isfile(REPO_CONTEXT):
+            with open(REPO_CONTEXT) as f:
+                repo_architecture = f.read()
+            print(f"  Loaded repo context from {REPO_CONTEXT} ({len(repo_architecture)} chars)")
 
         # ─── 5. Build prompt ──────────────────────────────────────────────
         system_prompt = textwrap.dedent("""\
-            You are a senior code reviewer. You ONLY report CRITICAL issues — bugs, security vulnerabilities, data loss, and crashes that MUST be fixed before merge.
+            You are a senior code reviewer.
 
-            RULES:
-            - ONLY comment on issues that will cause bugs, security holes, data loss, or crashes in production.
-            - Do NOT comment on style, naming, formatting, missing docs, type hints, or import ordering.
-            - Do NOT suggest alternatives, improvements, or "consider doing X".
-            - Do NOT comment on things that require full codebase context to verify.
-            - Do NOT nitpick. If you are not 90%+ confident it is a real production issue, do NOT comment.
-            - If no critical issues: return {"comments": []}
+            RESPONSE FORMAT:
             - Return ONLY valid JSON. No markdown fences, no explanation outside JSON.
-
-            WHAT IS CRITICAL:
-            - Hardcoded secrets/passwords/API keys
-            - Injection vulnerabilities (SQL, Cypher, command, prompt)
-            - Silent exception swallowing on critical paths (data loss)
-            - Command injection via shell=True or os.system with user input
-            - Missing timeout on external calls (can hang forever)
-            - PubSub messages ACKed before processing (data loss)
-            - Removed safety checks (validation, bounds, cleanup) without replacement
-            - Race conditions that cause data corruption
-            - Breaking changes to shared libraries without downstream updates
-
-            WHAT IS NOT CRITICAL (do NOT comment):
-            - Code style, naming conventions, formatting
-            - Missing error logging (unless it hides data loss)
-            - "Consider using X" suggestions
-            - Hypothetical issues
-            - Performance unless it causes OOM or timeout
-            - Missing tests
-            - Import ordering, unused imports
-            - Commented-out code
-
-            Response format — each comment MUST have these 4 fields:
+            - If no issues worth reporting: return {"comments": []}
+            - Each comment MUST have these 4 fields:
             {
               "comments": [
                 {
                   "path": "src/api/helpers.py",
                   "line": 42,
-                  "category": "Security|Data Loss|Reliability|Injection|Credentials",
-                  "body": "One sentence describing the problem. Keep it under 20 words."
+                  "category": "free-form string — use the severity or category from the review guidelines",
+                  "body": "Concise description of the problem (1-4 lines). No fix suggestion, no preamble."
                 }
               ]
             }
 
             IMPORTANT:
-            - "category" must be one of: Security, Data Loss, Reliability, Injection, Credentials
-            - "body" must be ONE short sentence — the problem only, no fix suggestion, no preamble
-            - Do NOT prefix body with "CRITICAL:" or any label — the category field handles that
-            - Do NOT write paragraphs — one sentence max""")
+            - "category" is a free-form string — use whatever severity level or category name the review guidelines specify
+            - "body" should be concise (1-4 lines) — describe the problem only, no fix suggestion, no preamble
+            - Do NOT prefix body with the category label — the category field handles that""")
 
-        if repo_context:
-            system_prompt += "\n\nREPO CONTEXT:\n" + repo_context
+        system_prompt += "\n\nREVIEW GUIDELINES (follow these as your primary review policy):\n" + review_policy
 
-        if CUSTOM_PROMPT:
-            system_prompt += "\n\nADDITIONAL INSTRUCTIONS:\n" + CUSTOM_PROMPT
+        if repo_architecture:
+            system_prompt += "\n\nREPOSITORY ARCHITECTURE (use this to understand the codebase):\n" + repo_architecture
 
         label = "incremental (new commits only)" if incremental else "full PR"
         user_prompt = textwrap.dedent(f"""\
-            Review this {label} diff. Return JSON only. Only CRITICAL issues.
+            Review this {label} diff. Return JSON only. Follow the review guidelines.
 
             Title: {pr_title}
             Description: {pr_body}
@@ -278,20 +256,40 @@ runs:
         # Post as PR review: summary body + inline comments on diff lines.
         # Also post an issue comment with SHA marker for incremental tracking.
         if not comments:
-            print("  No critical issues found.")
+            print("  No issues found.")
             cf = "/tmp/ai_review_comment.md"
             with open(cf, "w") as f:
-                f.write(f"No critical issues found.\n\n<!-- ai-review-sha:{head_sha} -->")
+                f.write(f"No issues found.\n\n<!-- ai-review-sha:{head_sha} -->")
             gh("pr", "comment", PR_NUMBER, "--repo", REPOSITORY, "--body-file", cf)
             out("review_status", "success"); out("comments_posted", "0"); sys.exit(0)
 
         # Category emoji mapping
         CAT_EMOJI = {
+            # Severity levels
+            "critical": "\U0001f6d1",
+            "high": "\U0001f534",
+            "medium": "\U0001f7e0",
+            "low": "\U0001f7e1",
+            # Original categories
             "security": "\U0001f6e1\ufe0f",
             "injection": "\U0001f489",
             "credentials": "\U0001f511",
             "data loss": "\U0001f4a5",
             "reliability": "\u26a0\ufe0f",
+            # REVIEW.md categories
+            "concurrency": "\U0001f500",
+            "performance": "\u26a1",
+            "design": "\U0001f4d0",
+            "go-specific": "\U0001f439",
+            "python/ai": "\U0001f40d",
+            "neo4j/cypher": "\U0001f4c0",
+            "database/migration": "\U0001f5c4\ufe0f",
+            "k8s": "\u2638\ufe0f",
+            "test coverage": "\U0001f9ea",
+            "monorepo/cross-service": "\U0001f517",
+            "breaking change": "\U0001f4a3",
+            "correctness": "\u2705",
+            "error handling": "\U0001f6a8",
         }
 
         def fmt_category(cat):
@@ -305,7 +303,7 @@ runs:
             path = c.get("path", "")
             line_num = c.get("line", 0)
             body = c.get("body", "")
-            cat = c.get("category", "Security")
+            cat = c.get("category", "")
             if path and line_num and body:
                 inline_body = f"{fmt_category(cat)}\n\n{body}"
                 review_comments.append({
@@ -316,14 +314,14 @@ runs:
                 })
 
         # Build formatted summary for the review body
-        summary_lines = [f"Found **{len(comments)}** critical issue(s):\n"]
+        summary_lines = [f"Found **{len(comments)}** issue(s):\n"]
         summary_lines.append("| | File | Issue |")
         summary_lines.append("|---|---|---|")
         for i, c in enumerate(comments, 1):
             path = c.get("path", "")
             line_num = c.get("line", 0)
             body = c.get("body", "").replace("|", "\\|")
-            cat = c.get("category", "Security")
+            cat = c.get("category", "")
             short_path = path.split("/")[-1] if "/" in path else path
             summary_lines.append(f"| {fmt_category(cat)} | `{short_path}:{line_num}` | {body} |")
         summary_body = "\n".join(summary_lines)

--- a/ai-review/action.yml
+++ b/ai-review/action.yml
@@ -281,7 +281,7 @@ runs:
             print("  No critical issues found.")
             cf = "/tmp/ai_review_comment.md"
             with open(cf, "w") as f:
-                f.write(f"## AI Code Review\n\nNo critical issues found.\n\n<!-- ai-review-sha:{head_sha} -->")
+                f.write(f"No critical issues found.\n\n<!-- ai-review-sha:{head_sha} -->")
             gh("pr", "comment", PR_NUMBER, "--repo", REPOSITORY, "--body-file", cf)
             out("review_status", "success"); out("comments_posted", "0"); sys.exit(0)
 
@@ -316,9 +316,7 @@ runs:
                 })
 
         # Build formatted summary for the review body
-        label = "new changes only" if incremental else "full diff"
-        summary_lines = [f"## AI Code Review ({label})\n"]
-        summary_lines.append(f"Found **{len(comments)}** critical issue(s):\n")
+        summary_lines = [f"Found **{len(comments)}** critical issue(s):\n"]
         summary_lines.append("| | File | Issue |")
         summary_lines.append("|---|---|---|")
         for i, c in enumerate(comments, 1):

--- a/ai-review/action.yml
+++ b/ai-review/action.yml
@@ -108,25 +108,29 @@ runs:
         print(f"  {head_branch} -> {base_branch} ({len(commits)} commits, HEAD {head_sha[:8]})")
 
         # ─── 2. Check for previous AI review ─────────────────────────────
+        # Use issue comments (not review comments) to track last reviewed SHA.
+        # We embed <!-- ai-review-sha:XXXX --> in our comment body.
+        import re as _re
         print("Checking for previous AI reviews...")
-        raw = gh("api", f"repos/{REPOSITORY}/pulls/{PR_NUMBER}/comments", "--paginate")
-        existing_comments = json.loads(raw) if raw else []
+        raw = gh("api", f"repos/{REPOSITORY}/issues/{PR_NUMBER}/comments", "--paginate")
+        issue_comments = json.loads(raw) if raw else []
 
-        # Find last reviewed commit from bot comments
         last_reviewed_sha = None
-        seen_lines = set()
-        for c in existing_comments:
+        for c in issue_comments:
             if c.get("user", {}).get("login") == BOT_USERNAME:
-                cid = c.get("commit_id")
-                if cid:
-                    last_reviewed_sha = cid
-                seen_lines.add(f"{c.get('path','')}:{c.get('line') or c.get('original_line') or 0}")
+                body = c.get("body", "")
+                m = _re.search(r'<!-- ai-review-sha:([a-f0-9]+) -->', body)
+                if m:
+                    last_reviewed_sha = m.group(1)
 
-        print(f"  {len(seen_lines)} existing bot comments, last reviewed: {last_reviewed_sha[:8] if last_reviewed_sha else 'none'}")
+        print(f"  Last reviewed SHA: {last_reviewed_sha[:8] if last_reviewed_sha else 'none'}, HEAD: {head_sha[:8]}")
 
         # ─── 3. Get diff ─────────────────────────────────────────────────
         incremental = False
-        if last_reviewed_sha and last_reviewed_sha != head_sha:
+        if last_reviewed_sha == head_sha:
+            print("  Already reviewed this commit. Skipping.")
+            out("review_status", "skipped"); out("comments_posted", "0"); sys.exit(0)
+        elif last_reviewed_sha:
             print(f"  Incremental diff: {last_reviewed_sha[:8]}..{head_sha[:8]}")
             diff = gh("api", f"repos/{REPOSITORY}/compare/{last_reviewed_sha}...{head_sha}",
                       "--jq", '.files[]? | "diff --git a/" + .filename + " b/" + .filename + "\\n" + (.patch // "")')
@@ -135,9 +139,6 @@ runs:
             else:
                 print("  No new changes since last review. Skipping.")
                 out("review_status", "skipped"); out("comments_posted", "0"); sys.exit(0)
-        elif last_reviewed_sha == head_sha:
-            print("  Already reviewed this commit. Skipping.")
-            out("review_status", "skipped"); out("comments_posted", "0"); sys.exit(0)
         else:
             print("  First review — full PR diff.")
             diff = gh("pr", "diff", PR_NUMBER, "--repo", REPOSITORY)
@@ -262,40 +263,36 @@ runs:
         comments = review.get("comments", [])
         print(f"  Claude returned {len(comments)} comment(s)")
 
-        # ─── 7. Dedup against existing bot comments ──────────────────────
-        final = []
-        for c in comments:
-            path = c.get("path", "")
-            line = c.get("line", 0)
-            if f"{path}:{line}" in seen_lines:
-                print(f"  Skipping duplicate: {path}:{line}")
-                continue
-            final.append(c)
-
-        print(f"  {len(final)} new comment(s) after dedup")
-
-        if not final:
+        # ─── 7. Post results ──────────────────────────────────────────────
+        # Single issue comment — no threads to resolve, no merge blockers.
+        # Embed SHA marker for incremental tracking on next push.
+        if not comments:
             print("  No critical issues found.")
+            cf = "/tmp/ai_review_comment.md"
+            with open(cf, "w") as f:
+                f.write(f"## AI Code Review\n\nNo critical issues found.\n\n<!-- ai-review-sha:{head_sha} -->")
+            gh("pr", "comment", PR_NUMBER, "--repo", REPOSITORY, "--body-file", cf)
             out("review_status", "success"); out("comments_posted", "0"); sys.exit(0)
 
-        # ─── 8. Post single formatted PR comment ─────────────────────────
-        # Single issue comment (not review/inline) — no threads to resolve.
-        lines = ["## :rotating_light: AI Code Review\n"]
-        for i, c in enumerate(final, 1):
+        label = "new changes only" if incremental else "full diff"
+        lines = [f"## AI Code Review ({label})\n"]
+        for i, c in enumerate(comments, 1):
             path = c.get("path", "")
             line = c.get("line", 0)
             body = c.get("body", "")
-            lines.append(f"### {i}. `{path}:{line}`")
-            lines.append(f"{body}\n")
+            lines.append(f"**{i}. `{path}:{line}`**")
+            lines.append(f"> {body}\n")
 
+        lines.append(f"\n<!-- ai-review-sha:{head_sha} -->")
         comment_body = "\n".join(lines)
+
         cf = "/tmp/ai_review_comment.md"
         with open(cf, "w") as f:
             f.write(comment_body)
 
         gh("pr", "comment", PR_NUMBER, "--repo", REPOSITORY, "--body-file", cf)
-        print(f"  Posted single comment with {len(final)} finding(s)")
-        out("review_status", "success"); out("comments_posted", str(len(final)))
+        print(f"  Posted comment with {len(comments)} finding(s)")
+        out("review_status", "success"); out("comments_posted", str(len(comments)))
 
         PYEOF
 

--- a/ai-review/action.yml
+++ b/ai-review/action.yml
@@ -264,8 +264,8 @@ runs:
         print(f"  Claude returned {len(comments)} comment(s)")
 
         # ─── 7. Post results ──────────────────────────────────────────────
-        # Single issue comment — no threads to resolve, no merge blockers.
-        # Embed SHA marker for incremental tracking on next push.
+        # Post as PR review: summary body + inline comments on diff lines.
+        # Also post an issue comment with SHA marker for incremental tracking.
         if not comments:
             print("  No critical issues found.")
             cf = "/tmp/ai_review_comment.md"
@@ -274,25 +274,70 @@ runs:
             gh("pr", "comment", PR_NUMBER, "--repo", REPOSITORY, "--body-file", cf)
             out("review_status", "success"); out("comments_posted", "0"); sys.exit(0)
 
+        # Build inline review comments for the diff
+        review_comments = []
+        for c in comments:
+            path = c.get("path", "")
+            line_num = c.get("line", 0)
+            body = c.get("body", "")
+            if path and line_num and body:
+                review_comments.append({
+                    "path": path,
+                    "line": int(line_num),
+                    "side": "RIGHT",
+                    "body": f"**CRITICAL:** {body}"
+                })
+
+        # Build formatted summary for the review body
         label = "new changes only" if incremental else "full diff"
-        lines = [f"## AI Code Review ({label})\n"]
+        summary_lines = [f"## AI Code Review ({label})\n"]
+        summary_lines.append(f"Found **{len(comments)}** critical issue(s):\n")
         for i, c in enumerate(comments, 1):
             path = c.get("path", "")
-            line = c.get("line", 0)
+            line_num = c.get("line", 0)
             body = c.get("body", "")
-            lines.append(f"**{i}. `{path}:{line}`**")
-            lines.append(f"> {body}\n")
+            summary_lines.append(f"**{i}.** [`{path}:{line_num}`](https://github.com/{REPOSITORY}/pull/{PR_NUMBER}/files#diff-{path})")
+            summary_lines.append(f"> {body}\n")
+        summary_body = "\n".join(summary_lines)
 
-        lines.append(f"\n<!-- ai-review-sha:{head_sha} -->")
-        comment_body = "\n".join(lines)
+        # Submit PR review with inline comments + summary body
+        review_payload = {
+            "body": summary_body,
+            "event": "COMMENT",
+            "commit_id": head_sha,
+            "comments": review_comments
+        }
 
-        cf = "/tmp/ai_review_comment.md"
-        with open(cf, "w") as f:
-            f.write(comment_body)
+        payload_file = "/tmp/ai_review_payload.json"
+        with open(payload_file, "w") as f:
+            json.dump(review_payload, f)
 
-        gh("pr", "comment", PR_NUMBER, "--repo", REPOSITORY, "--body-file", cf)
-        print(f"  Posted comment with {len(comments)} finding(s)")
-        out("review_status", "success"); out("comments_posted", str(len(comments)))
+        result = subprocess.run(
+            ["gh", "api", f"repos/{REPOSITORY}/pulls/{PR_NUMBER}/reviews",
+             "--input", payload_file, "--method", "POST"],
+            capture_output=True, text=True, timeout=120, env={**os.environ}
+        )
+
+        if result.returncode != 0:
+            print(f"  Review API failed: {result.stderr[:500]}")
+            print("  Falling back to summary-only comment...")
+            cf = "/tmp/ai_review_comment.md"
+            with open(cf, "w") as f:
+                f.write(summary_body)
+            gh("pr", "comment", PR_NUMBER, "--repo", REPOSITORY, "--body-file", cf)
+
+            posted = len(comments)
+        else:
+            print(f"  Posted review with {len(review_comments)} inline comment(s) + summary")
+            posted = len(review_comments)
+
+        # Always post SHA tracker as issue comment for incremental tracking
+        sha_cf = "/tmp/ai_review_sha.md"
+        with open(sha_cf, "w") as f:
+            f.write(f"<!-- ai-review-sha:{head_sha} -->")
+        gh("pr", "comment", PR_NUMBER, "--repo", REPOSITORY, "--body-file", sha_cf)
+
+        out("review_status", "success"); out("comments_posted", str(posted))
 
         PYEOF
 

--- a/ai-review/action.yml
+++ b/ai-review/action.yml
@@ -76,6 +76,7 @@ runs:
         import os
         import subprocess
         import sys
+        import textwrap
         import urllib.request
         import urllib.error
 
@@ -166,83 +167,84 @@ runs:
 
         # ─── 6. Build prompt ──────────────────────────────────────────────
         # System prompt = REVIEW.md guidelines (Tilda-specific)
-        system_prompt = """You are a code review agent for Tilda, a biotech platform.
+        system_prompt = textwrap.dedent(f"""\
+            You are a code review agent for Tilda, a biotech platform.
 
-RULES — read these first:
-- Signal > volume. If unsure whether something is a real issue, do NOT comment.
-- Report ALL CRITICAL issues — no limit. For HIGH/MEDIUM, limit to """ + str(MAX_COMMENTS) + """ comments. Prioritize highest impact.
-- If a CRITICAL issue exists, report it first. Continue reviewing for other CRITICAL issues but skip non-critical observations.
-- Return ONLY valid JSON. No markdown fences, no explanation outside JSON.
-- Each comment: file path + line number (from ADDED side, calculated from @@ hunk headers) + 1-4 line body with concrete fix.
-- Severity tags: [CRITICAL] must fix before merge, [HIGH] strongly recommended, [MEDIUM] improvement.
-- Do NOT use [LOW]. If it is not materially impactful, do not comment.
-- If no issues: return {"summary": "LGTM", "comments": []}
-- No summary paragraph. No praise. Only findings.
+            RULES — read these first:
+            - Signal > volume. If unsure whether something is a real issue, do NOT comment.
+            - Report ALL CRITICAL issues — no limit. For HIGH/MEDIUM, limit to {MAX_COMMENTS} comments. Prioritize highest impact.
+            - If a CRITICAL issue exists, report it first. Continue reviewing for other CRITICAL issues but skip non-critical observations.
+            - Return ONLY valid JSON. No markdown fences, no explanation outside JSON.
+            - Each comment: file path + line number (from ADDED side, calculated from @@ hunk headers) + 1-4 line body with concrete fix.
+            - Severity tags: [CRITICAL] must fix before merge, [HIGH] strongly recommended, [MEDIUM] improvement.
+            - Do NOT use [LOW]. If it is not materially impactful, do not comment.
+            - If no issues: return {{"summary": "LGTM", "comments": []}}
+            - No summary paragraph. No praise. Only findings.
 
-REPOSITORY CONTEXT:
-This is a monorepo with:
-- ~18 Go microservices (execsvc, docsvc, patientsvc, schedsvc, enrollsvc, studiosvc, finsvc, notifsvc, dslsvc, authz, dashQL, dashRsvc, regsvc, advpsvc, workplansvc, datasvc, payoutsvc, tusker)
-- Shared Go libraries (common/, tildadb/, tildaobj/, api/, tlang/, util/) — changes here affect many services
-- Python AI services under data-science/ (studioai, virtual_assistant, docproc, exportsvc) — LangChain, OpenAI, Neo4j, PubSub
-- Neo4j as primary database with Cypher queries
-- Google Cloud Pub/Sub for async messaging (at-least-once delivery — consumers must be idempotent)
-- GraphQL (gqlgen) in dashQL
-- GitHub Actions CI/CD
+            REPOSITORY CONTEXT:
+            This is a monorepo with:
+            - ~18 Go microservices (execsvc, docsvc, patientsvc, schedsvc, enrollsvc, studiosvc, finsvc, notifsvc, dslsvc, authz, dashQL, dashRsvc, regsvc, advpsvc, workplansvc, datasvc, payoutsvc, tusker)
+            - Shared Go libraries (common/, tildadb/, tildaobj/, api/, tlang/, util/) — changes here affect many services
+            - Python AI services under data-science/ (studioai, virtual_assistant, docproc, exportsvc) — LangChain, OpenAI, Neo4j, PubSub
+            - Neo4j as primary database with Cypher queries
+            - Google Cloud Pub/Sub for async messaging (at-least-once delivery — consumers must be idempotent)
+            - GraphQL (gqlgen) in dashQL
+            - GitHub Actions CI/CD
 
-PR NECESSITY CHECK (do first):
-- Is this PR necessary? Could the goal be achieved simpler?
-- Does the diff include unrelated changes? Unnecessary abstractions?
-- Flag over-engineering before reviewing code details.
+            PR NECESSITY CHECK (do first):
+            - Is this PR necessary? Could the goal be achieved simpler?
+            - Does the diff include unrelated changes? Unnecessary abstractions?
+            - Flag over-engineering before reviewing code details.
 
-WHAT TO CHECK:
+            WHAT TO CHECK:
 
-1. Correctness: Logic errors, null dereferences, wrong variable, off-by-one, incorrect control flow
-2. Security: Hardcoded secrets, injection (SQL, Cypher, command, prompt), missing auth, PHI/PII exposure, insecure crypto
-3. Concurrency: Goroutines without context cancellation, unsafe concurrent map access, race conditions, blocking calls in goroutines
-4. Distributed reliability: Non-idempotent retries, at-least-once vs exactly-once confusion, missing partial failure handling, PubSub ack/nack errors silently swallowed
-5. Error handling: Silent except/pass, missing error handling on DB/API/message paths, ignored Go error returns, panics in production
-6. Data integrity: Messages dropped, partial writes without rollback, state corruption, Neo4j session/transaction not closed
-7. Breaking changes: Shared library changes without downstream consideration, API contract changes, schema changes breaking rolling deploys, removed fields callers depend on
-8. Performance: N+1 Cypher queries in loops, unbounded memory, missing pagination, full graph scans
-9. Cross-service impact: Changes to common/, tildaobj/, tildadb/ affect all services — increase severity by one level for shared code changes
+            1. Correctness: Logic errors, null dereferences, wrong variable, off-by-one, incorrect control flow
+            2. Security: Hardcoded secrets, injection (SQL, Cypher, command, prompt), missing auth, PHI/PII exposure, insecure crypto
+            3. Concurrency: Goroutines without context cancellation, unsafe concurrent map access, race conditions, blocking calls in goroutines
+            4. Distributed reliability: Non-idempotent retries, at-least-once vs exactly-once confusion, missing partial failure handling, PubSub ack/nack errors silently swallowed
+            5. Error handling: Silent except/pass, missing error handling on DB/API/message paths, ignored Go error returns, panics in production
+            6. Data integrity: Messages dropped, partial writes without rollback, state corruption, Neo4j session/transaction not closed
+            7. Breaking changes: Shared library changes without downstream consideration, API contract changes, schema changes breaking rolling deploys, removed fields callers depend on
+            8. Performance: N+1 Cypher queries in loops, unbounded memory, missing pagination, full graph scans
+            9. Cross-service impact: Changes to common/, tildaobj/, tildadb/ affect all services — increase severity by one level for shared code changes
 
-GO-SPECIFIC:
-- Missing or ignored error returns
-- Goroutines without context cancellation
-- Unsafe concurrent map access
-- Panics in production paths
-- Neo4j session/transaction not closed
-- Cypher injection via string concatenation (must use parameterized queries)
-- Missing timeout on external calls
+            GO-SPECIFIC:
+            - Missing or ignored error returns
+            - Goroutines without context cancellation
+            - Unsafe concurrent map access
+            - Panics in production paths
+            - Neo4j session/transaction not closed
+            - Cypher injection via string concatenation (must use parameterized queries)
+            - Missing timeout on external calls
 
-PYTHON-SPECIFIC:
-- Blocking I/O inside async code
-- Silent exception swallowing (bare except/pass on critical paths)
-- User input concatenated into LLM prompts
-- LLM responses used without validation
-- Unbounded agent loops (missing max iterations)
-- Missing resource cleanup
+            PYTHON-SPECIFIC:
+            - Blocking I/O inside async code
+            - Silent exception swallowing (bare except/pass on critical paths)
+            - User input concatenated into LLM prompts
+            - LLM responses used without validation
+            - Unbounded agent loops (missing max iterations)
+            - Missing resource cleanup
 
-NEO4J/CYPHER:
-- Non-existent node labels or relationship types (verify against tildaobj/ if visible)
-- Relationships traversed in wrong direction
-- String concatenation instead of parameterized queries
-- Queries causing full graph scans (missing WHERE clause on indexed property)
+            NEO4J/CYPHER:
+            - Non-existent node labels or relationship types (verify against tildaobj/ if visible)
+            - Relationships traversed in wrong direction
+            - String concatenation instead of parameterized queries
+            - Queries causing full graph scans (missing WHERE clause on indexed property)
 
-WHAT NOT TO CHECK:
-- Formatting, naming, import ordering, type hints
-- Missing docstrings or comments
-- "Consider using X instead of Y" suggestions
-- Hypothetical issues requiring full codebase context to verify
-- Non-critical optimizations
-- Alternative architectures
+            WHAT NOT TO CHECK:
+            - Formatting, naming, import ordering, type hints
+            - Missing docstrings or comments
+            - "Consider using X instead of Y" suggestions
+            - Hypothetical issues requiring full codebase context to verify
+            - Non-critical optimizations
+            - Alternative architectures
 
-Response format:
-{
-  "comments": [
-    {"path": "file.go", "line": 42, "body": "[CRITICAL] Description. Fix: ..."}
-  ]
-}"""
+            Response format:
+            {{
+              "comments": [
+                {{"path": "file.go", "line": 42, "body": "[CRITICAL] Description. Fix: ..."}}
+              ]
+            }}""")
 
         # Append repo-specific context if available
         if repo_context:
@@ -252,16 +254,17 @@ Response format:
             system_prompt += "\n\nADDITIONAL INSTRUCTIONS:\n" + CUSTOM_PROMPT
 
         label = "incremental (new commits only)" if incremental else "full PR"
-        user_prompt = f"""Review this {label} diff. Return JSON only.
+        user_prompt = textwrap.dedent(f"""\
+            Review this {label} diff. Return JSON only.
 
-Title: {pr_title}
-Description: {pr_body}
-Branch: {head_branch} -> {base_branch}
+            Title: {pr_title}
+            Description: {pr_body}
+            Branch: {head_branch} -> {base_branch}
 
-Diff:
-```diff
-{diff}
-```"""
+            Diff:
+            ```diff
+            {diff}
+            ```""")
 
         # ─── 7. Call Claude ───────────────────────────────────────────────
         print(f"Calling Claude ({MODEL})...")


### PR DESCRIPTION
## Summary
- Triple-quoted Python strings inside the `run: |` YAML block scalar had content starting at column 0, which broke YAML parsing
- Wrapped multiline strings with `textwrap.dedent()` and proper indentation so all content stays within the YAML block scalar
- Fixes workflow failure on PR #11773 in main repo

## Test plan
- [x] Validated YAML parses correctly with `yaml.safe_load()`
- [x] Validated embedded Python compiles with `compile()`