### PR TITLE
build-and-push: map production_hotfixes to production tag prefix

### DIFF
--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -73,7 +73,7 @@ runs:
         images: |
           ${{ inputs.artifactory-url }}/${{ inputs.google-project }}/artifacts/services/${{ inputs.service-name }}
         tags: |
-          type=sha,enable=true,priority=100,prefix=${{ github.head_ref || github.ref_name}}-,suffix=,format=short
+          type=sha,enable=true,priority=100,prefix=${{ (github.head_ref || github.ref_name) == 'production_hotfixes' && 'production' || (github.head_ref || github.ref_name) }}-,suffix=,format=short
 
     - uses: docker/build-push-action@v2
       with:


### PR DESCRIPTION
## Summary

Pushes to the `production_hotfixes` branch in `tildabio/main` need to produce images tagged `production-<sha>` (not `production_hotfixes-<sha>`), so they roll out via the same gitops path as production builds.

One-line change to the `docker/metadata-action` prefix expression in `build-and-push/action.yml:76`:

```yaml
prefix=${{ (github.head_ref || github.ref_name) == 'production_hotfixes' && 'production' || (github.head_ref || github.ref_name) }}-
```

- Only rewrites the prefix when the source branch is `production_hotfixes`
- All other branches (master, feature branches, dependabot, etc.) keep the existing `<branch>-` prefix

## Test plan

- [ ] Merge, then push to `production_hotfixes` in `tildabio/main` and confirm Artifact Registry gets `<service>:production-<sha>` (not `production_hotfixes-<sha>`)