### PR TITLE
feat: ai-review-v2 — self-hosted LLM PR reviewer with codegraph + learnings

### DIFF
--- a/ai-review-v2/.review.yaml.example
+++ b/ai-review-v2/.review.yaml.example
@@ -1,0 +1,72 @@
+# Drop this at the root of any repo to customize review behavior.
+# All keys are optional. Environment-variable inputs from the action override
+# anything set here.
+
+# ---- Models (usually set via action inputs; here for reference) ----
+# review:
+#   base_url: https://api.openai.com/v1
+#   model: gpt-4o
+# triage:
+#   model: gpt-4o-mini
+# embedding:
+#   base_url: https://api.openai.com/v1
+#   model: text-embedding-3-small
+#   dimensions: 1536
+
+# ---- Feature toggles ----
+features:
+  analyzers:   true
+  codegraph:   true
+  learnings:   true
+  incremental: true
+
+# ---- Limits ----
+limits:
+  max_files: 50
+  max_file_bytes: 100000
+  confidence: 3      # findings below this confidence (1-5) are dropped
+  parallel: 6        # how many files to review in parallel
+
+# ---- State branch for the SQLite knowledge DB ----
+state:
+  branch: __reviewer_state__
+
+# ---- Additional skip patterns (extend the built-in defaults) ----
+skip_patterns:
+  - "**/*.snap"          # jest snapshots
+  - "**/testdata/**"
+  - "schemas/generated/**"
+
+# ---- Path-based review instructions ----
+# Glob patterns are gitignore-style. Instructions are injected into the per-file
+# review prompt for any matching file.
+path_instructions:
+  - pattern: "src/api/**"
+    instructions: |
+      Public API surface. Be strict about:
+      - Breaking changes to function signatures or returned shapes
+      - Missing auth/permission checks on new endpoints
+      - Lack of input validation on user-controlled fields
+      - Missing tests in tests/api/
+
+  - pattern: "src/db/**"
+    instructions: |
+      Database layer. Be strict about:
+      - N+1 query patterns
+      - Missing indexes on new query patterns
+      - Transactions not properly scoped
+      - SQL injection via string concatenation (we use parameterized queries)
+
+  - pattern: "**/*.tsx"
+    instructions: |
+      React components:
+      - useEffect cleanup functions must cancel async work
+      - useCallback/useMemo dependencies must be exhaustive
+      - No direct DOM manipulation outside refs
+
+  - pattern: "infra/**"
+    instructions: |
+      Infrastructure code (Terraform/Pulumi):
+      - All secrets must go through the central secret manager
+      - Resources must have ownership tags
+      - Public-facing resources require explicit approval in PR description

--- a/ai-review-v2/README.md
+++ b/ai-review-v2/README.md
@@ -1,0 +1,320 @@
+# PR Reviewer v2
+
+LLM-agnostic AI PR reviewer with **codegraph**, **persistent learnings**, and
+**incremental review state**. Designed to deliver CodeRabbit-class reviews
+without per-seat pricing.
+
+Talks to any OpenAI-compatible `chat/completions` and `/v1/embeddings` endpoint.
+Self-hosted via a single GitHub Action. State lives in a SQLite DB persisted
+on an orphan branch in your repo — zero external infrastructure.
+
+---
+
+## What's new in v2
+
+| Capability | v1 | v2 |
+|---|---|---|
+| Multi-pass pipeline (triage / summary / per-file / cross-cut) | ✅ | ✅ |
+| Static analyzers as noise filter | ✅ | ✅ |
+| Path-based review instructions | — | ✅ (`.review.yaml`) |
+| Cross-file caller context (codegraph) | — | ✅ (tree-sitter + ripgrep) |
+| Persistent learnings (memory) | — | ✅ (sqlite-vec) |
+| Incremental review (don't re-check unchanged files) | — | ✅ |
+| Idempotent posting (no duplicate reviews on retries) | — | ✅ |
+| Failed-CI log enrichment | — | ✅ |
+| Cost telemetry (per-call usage logged to SQLite) | — | ✅ |
+| Retry with backoff (tenacity) | — | ✅ |
+| Skeletal test coverage | — | ✅ (extend as you go) |
+
+---
+
+## Architecture
+
+```
+                    ┌─────────────────────────────────┐
+   PR opened   →    │  action.yml (composite)         │
+                    │  → python -m src review         │
+                    └─────────────────────────────────┘
+                                  │
+                                  ▼
+              ┌───────────────────────────────────────┐
+              │  StateBranch.setup()                  │
+              │  clones __reviewer_state__ → /tmp/    │
+              │  opens state.db (sqlite-vec loaded)   │
+              └───────────────────────────────────────┘
+                                  │
+                                  ▼
+   ┌─── orchestrator.review_pr() ────────────────────────────────┐
+   │  1. Idempotency check (skip if head_sha already reviewed)   │
+   │  2. Incremental filter (only files w/ changed blob_sha)     │
+   │  3. Triage           ← cheap model                          │
+   │  4. Static analyzers ← ruff/eslint/semgrep/gitleaks/etc.    │
+   │  5. Codegraph        ← tree-sitter symbols + rg references  │
+   │  6. Learnings        ← embed file → vec MATCH in SQLite     │
+   │  7. Summary          ← smart model, 1 call, w/ CI logs      │
+   │  8. Per-file review  ← smart model, N parallel              │
+   │                        prompt includes:                     │
+   │                          - analyzer output                  │
+   │                          - codegraph callers                │
+   │                          - top-K learnings                  │
+   │                          - matched path instructions        │
+   │  9. Cross-cut        ← smart model, 1 call, verdict         │
+   │ 10. Filter by confidence threshold                          │
+   │ 11. Post single GitHub Review (inline + summary)            │
+   │ 12. Save state (per-file blob_sha, review_id)               │
+   └─────────────────────────────────────────────────────────────┘
+                                  │
+                                  ▼
+              ┌───────────────────────────────────────┐
+              │  StateBranch.commit_and_push()        │
+              │  pull-rebase loop on conflict (5x)    │
+              └───────────────────────────────────────┘
+```
+
+Separate workflow (`learn.yml`) listens for `@reviewer` mentions on PR comments
+and extracts durable learnings:
+
+```
+   PR comment    →   issue_comment / pull_request_review_comment event
+   "@reviewer       ↓
+    we use early    learn.process_comment_event()
+    returns          ├── detect parent review comment
+    here, not        ├── LLM: is this a durable team preference?
+    nested try"      ├── if yes: embed + insert into learnings + learnings_vec
+                     └── reply: "🧠 Learning #42 added"
+```
+
+---
+
+## What the codegraph actually does
+
+When file `src/auth/middleware.py` is changed, the codegraph pass:
+
+1. **Parses** the file with tree-sitter, extracting every function, class, and
+   method definition with its line range.
+2. **Filters** to "touched symbols" — definitions whose body overlaps the diff
+   hunks. If you only changed lines 45-50 inside `validate_token()`, only
+   `validate_token` is considered touched.
+3. **Greps** the rest of the repo (via ripgrep, with the right `--type` filter)
+   for call sites of each touched symbol, capturing ±2 lines of context per hit.
+4. **Injects** up to 5 caller snippets per symbol into the per-file review
+   prompt, under an `EXTERNAL CALLERS OF MODIFIED SYMBOLS:` block.
+
+This is the difference between "your function looks fine" and "your function's
+new third parameter is required, but the caller at `api/users.py:88` still
+passes two args."
+
+Symbol indices are **cached** in SQLite keyed by `content_sha`, so unchanged
+files are never re-parsed.
+
+---
+
+## What the learnings system actually does
+
+1. A reviewer comment fires. A dev replies: `@reviewer we prefer Result<T, E>
+   over throwing in this module, see RFC-42`.
+2. The `learn.yml` workflow triggers. It fetches the parent review comment
+   and sends both to the LLM with `LEARNING_EXTRACT_SYSTEM`.
+3. The LLM returns:
+   ```json
+   {
+     "is_learning": true,
+     "description": "In src/result/**, prefer Result<T,E> over exception-based control flow because we want explicit error paths per RFC-42.",
+     "scope": "repo",
+     "file_pattern": "src/result/**"
+   }
+   ```
+4. We embed the description, insert into both `learnings` and `learnings_vec`,
+   reply on the PR with `🧠 Learning #42 added`.
+5. On the **next** review pass, when reviewing files matching `src/result/**`,
+   we embed the file path+content, do a vec MATCH against `learnings_vec`,
+   filter results by `file_pattern`, and inject the top-6 into the prompt.
+
+Forgetting: any user can reply `@reviewer forget #42` to deactivate a learning.
+
+---
+
+## Setup
+
+### 1. Publish this as a versioned action
+
+The simplest path: push this directory to a public or private GitHub repo
+(e.g. `your-org/pr-review-action-v2`), tag `v2.0.0`, and reference it from
+consumer workflows.
+
+### 2. Add the workflows to a target repo
+
+Copy `workflows/review.yml` and `workflows/learn.yml` to `.github/workflows/`
+in any repo you want reviewed. Pick a provider and fill in the secrets.
+
+### 3. Set up secrets
+
+You need at minimum:
+- `GITHUB_TOKEN` — auto-provided, but requires `contents: write` permission
+  in the workflow (already set in the example).
+- Your LLM provider's API key, e.g. `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`.
+- If using Anthropic as the review model, **also** provide an OpenAI or Voyage
+  key for embeddings (Anthropic has no `/v1/embeddings`).
+
+### 4. (Optional) Add `.review.yaml` to the target repo
+
+Copy `.review.yaml.example` to `.review.yaml`, prune what you don't need, and
+add path-based instructions for your hot paths (`src/api/**`, `src/db/**`,
+etc).
+
+### 5. (Optional) Add `CLAUDE.md` or `AGENTS.md` at the repo root
+
+The orchestrator auto-loads the first of:
+`CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.windsurfrules`,
+`CODESTYLE.md`, `STYLEGUIDE.md`, `CONTRIBUTING.md`.
+
+This goes into both the summary and per-file review prompts as
+`REPO CONVENTIONS`.
+
+### 6. First run
+
+Open or push a PR. On the first run, the action:
+- Creates the `__reviewer_state__` orphan branch (commit: "init: reviewer state")
+- Runs the full pipeline (no incremental, no learnings yet)
+- Pushes the populated `state.db` back to `__reviewer_state__`
+
+Subsequent runs reuse the state and get faster + smarter.
+
+---
+
+## Provider matrix
+
+| Provider | base_url | model example | embeddings? |
+|---|---|---|---|
+| OpenAI | `https://api.openai.com/v1` | `gpt-4o`, `gpt-4o-mini` | yes |
+| Anthropic | `https://api.anthropic.com/v1` | `claude-opus-4-7` | **no — point embed-* at OpenAI/Voyage** |
+| Google Gemini | `https://generativelanguage.googleapis.com/v1beta/openai` | `gemini-2.5-pro` | yes |
+| DeepSeek | `https://api.deepseek.com/v1` | `deepseek-chat` | yes |
+| Groq | `https://api.groq.com/openai/v1` | `llama-3.3-70b-versatile` | no |
+| OpenRouter | `https://openrouter.ai/api/v1` | many | yes |
+| Ollama | `http://localhost:11434/v1` | `qwen2.5-coder:32b`, `nomic-embed-text` | yes |
+
+---
+
+## Operating cost (rough)
+
+Per PR (200 lines, 5 files), single review pass:
+
+| Stage | Tokens in | Tokens out | gpt-4o cost | Sonnet cost | DeepSeek cost |
+|---|---|---|---|---|---|
+| Triage | 1.5K | 0.2K | $0.005 | $0.005 | $0.0003 |
+| Summary | 8K | 1.5K | $0.04 | $0.03 | $0.002 |
+| Per-file × 5 | 6K each | 1K each | $0.18 | $0.13 | $0.008 |
+| Cross-cut | 4K | 0.8K | $0.02 | $0.016 | $0.001 |
+| Embeddings × ~10 | 2K each | — | $0.0004 | (via OpenAI) | (via DeepSeek) |
+| **Total** | | | **~$0.25** | **~$0.18** | **~$0.012** |
+
+At 500 PRs/month: **$125/mo (gpt-4o) to $6/mo (DeepSeek)**.
+
+Telemetry is logged to the `llm_calls` table in `state.db` — query it for real
+numbers from your traffic:
+
+```sql
+SELECT
+  stage,
+  COUNT(*) calls,
+  SUM(prompt_tokens) input_tokens,
+  SUM(completion_tokens) output_tokens,
+  AVG(duration_ms) avg_ms
+FROM llm_calls
+WHERE created_at > datetime('now', '-30 days')
+GROUP BY stage;
+```
+
+---
+
+## Operations
+
+### Backing up state
+The state branch IS your backup. To snapshot:
+```bash
+git clone --branch __reviewer_state__ --depth 1 https://github.com/your-org/repo state-snapshot
+```
+
+### Browsing learnings
+```bash
+git fetch origin __reviewer_state__:__reviewer_state__
+git checkout __reviewer_state__
+sqlite3 state.db "SELECT id, description, scope, file_pattern, usage_count FROM learnings WHERE active = 1 ORDER BY usage_count DESC LIMIT 20"
+```
+
+### Resetting state (start over)
+```bash
+git push origin --delete __reviewer_state__
+```
+Next PR run will reinitialize.
+
+### Querying cost
+See the SQL snippet above.
+
+### Pausing the reviewer on a specific PR
+Add label `skip-review` to the PR. Then edit `orchestrator.review_pr()` to
+early-return if `pr['labels']` contains `skip-review` — left as an exercise.
+
+---
+
+## Files
+
+```
+action.yml              Composite GitHub Action (entry point)
+schema.sql              SQLite schema (versioned)
+pyproject.toml          Dependencies + project metadata
+.review.yaml.example    Per-repo config template
+src/
+  __init__.py
+  __main__.py           CLI dispatcher: 'review' | 'learn'
+  config.py             Env + YAML config loader
+  prompts.py            All prompts (the high-leverage file)
+  llm.py                OpenAI-compatible client + JSON parsing + embeddings
+  github_api.py         gh CLI wrappers, PR data, posting, state branch sync
+  analyzers.py          ruff/eslint/semgrep/gitleaks/etc runners
+  codegraph.py          Tree-sitter symbols + ripgrep callers
+  knowledge.py          SQLite + sqlite-vec: learnings, state, codegraph cache
+  orchestrator.py       The 5-pass pipeline
+  learn.py              @-mention listener → learnings extraction
+workflows/
+  review.yml            Triggers on PR events
+  learn.yml             Triggers on PR comments
+tests/
+  test_basics.py        Starter coverage; extend as you iterate
+```
+
+---
+
+## v3 roadmap (deferred from v2)
+
+In priority order if you want to keep going:
+
+1. **PR compression for huge diffs.** When the diff exceeds the model's token
+   budget, summarize less-important hunks (deletions, generated code, far-from-
+   center) and keep critical hunks verbatim. Steal PR-Agent's strategy.
+2. **AST-based path instructions.** Beyond globs, match by tree-sitter pattern
+   (e.g. "any function decorated with `@route`").
+3. **Multi-repo codegraph.** For monorepos with multiple service dirs, share
+   a single state branch and let callers cross service boundaries.
+4. **Web dashboard.** A tiny static-site generator that reads `state.db` and
+   renders the learnings + cost dashboards as a GitHub Pages site.
+5. **Slop detection.** Flag AI-generated PRs that look superficially correct
+   but skip error handling or duplicate existing logic.
+6. **Auto-approve trivia.** When triage says `skip` AND the change matches
+   patterns like "version bump", "typo fix", or "dependency-only update",
+   post an approval rather than a comment.
+
+---
+
+## Maintenance commitment
+
+You're the maintainer. The prompts in `src/prompts.py` are where you'll spend
+most of your tuning time as you see what the model gets wrong on your codebase.
+Two practices that pay off:
+
+1. **Weekly:** scan low-confidence findings that got posted anyway. Either
+   raise the threshold or add a "DO NOT FLAG" example to the prompt.
+2. **Monthly:** browse the `learnings` table. Delete stale ones (deprecated
+   patterns, departed teammates' preferences). Active count > 100 with usage
+   > 5 each is healthy.

--- a/ai-review-v2/action.yml
+++ b/ai-review-v2/action.yml
@@ -1,0 +1,142 @@
+name: 'PR Reviewer'
+description: 'LLM-agnostic AI PR reviewer with codegraph, learnings, and incremental state'
+author: 'you'
+branding:
+  icon: 'check-circle'
+  color: 'orange'
+
+inputs:
+  mode:
+    description: "'review' (default) for PR review, 'learn' for processing @-mention comments"
+    required: false
+    default: 'review'
+
+  # ---- Primary review model ----
+  review-api-key:
+    description: 'API key for the primary review model'
+    required: true
+  review-base-url:
+    description: 'OpenAI-compatible base URL'
+    required: false
+    default: 'https://api.openai.com/v1'
+  review-model:
+    description: 'Model id for deep review passes (file review, summary, cross-cut)'
+    required: false
+    default: 'gpt-4o'
+
+  # ---- Triage model (cheap) ----
+  triage-api-key:
+    description: 'Defaults to review-api-key'
+    required: false
+  triage-base-url:
+    description: 'Defaults to review-base-url'
+    required: false
+  triage-model:
+    required: false
+    default: 'gpt-4o-mini'
+
+  # ---- Embedding model (for learnings vector search) ----
+  embed-api-key:
+    description: 'Defaults to review-api-key. Anthropic-only setups should point this at OpenAI or Voyage.'
+    required: false
+  embed-base-url:
+    required: false
+  embed-model:
+    required: false
+    default: 'text-embedding-3-small'
+  embed-dimensions:
+    required: false
+    default: '1536'
+
+  # ---- Behavior ----
+  max-files:
+    required: false
+    default: '50'
+  confidence-threshold:
+    required: false
+    default: '3'
+  enable-codegraph:
+    required: false
+    default: 'true'
+  enable-learnings:
+    required: false
+    default: 'true'
+  enable-incremental:
+    required: false
+    default: 'true'
+  state-branch:
+    description: 'Orphan branch name where the SQLite DB is persisted'
+    required: false
+    default: '__reviewer_state__'
+
+  github-token:
+    description: 'Token with contents:write (for state branch) and pull-requests:write'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout PR head (review mode)
+      if: inputs.mode == 'review'
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Checkout default branch (learn mode)
+      if: inputs.mode == 'learn'
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install ripgrep (needed for codegraph)
+      shell: bash
+      run: |
+        if ! command -v rg >/dev/null; then
+          sudo apt-get update -qq
+          sudo apt-get install -y ripgrep
+        fi
+
+    - name: Install Python deps
+      shell: bash
+      working-directory: ${{ github.action_path }}
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+        # Best-effort: language-specific analyzers
+        pip install --quiet ruff bandit semgrep 2>/dev/null || true
+
+    - name: Run
+      shell: bash
+      working-directory: ${{ github.workspace }}
+      env:
+        REVIEW_API_KEY: ${{ inputs.review-api-key }}
+        REVIEW_BASE_URL: ${{ inputs.review-base-url }}
+        REVIEW_MODEL: ${{ inputs.review-model }}
+        TRIAGE_API_KEY: ${{ inputs.triage-api-key }}
+        TRIAGE_BASE_URL: ${{ inputs.triage-base-url }}
+        TRIAGE_MODEL: ${{ inputs.triage-model }}
+        EMBED_API_KEY: ${{ inputs.embed-api-key }}
+        EMBED_BASE_URL: ${{ inputs.embed-base-url }}
+        EMBED_MODEL: ${{ inputs.embed-model }}
+        EMBED_DIMENSIONS: ${{ inputs.embed-dimensions }}
+        MAX_FILES: ${{ inputs.max-files }}
+        CONFIDENCE_THRESHOLD: ${{ inputs.confidence-threshold }}
+        ENABLE_CODEGRAPH: ${{ inputs.enable-codegraph }}
+        ENABLE_LEARNINGS: ${{ inputs.enable-learnings }}
+        ENABLE_INCREMENTAL: ${{ inputs.enable-incremental }}
+        STATE_BRANCH: ${{ inputs.state-branch }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GH_TOKEN: ${{ inputs.github-token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      run: |
+        cd ${{ github.action_path }}
+        python -m src ${{ inputs.mode }}

--- a/ai-review-v2/action.yml
+++ b/ai-review-v2/action.yml
@@ -148,4 +148,10 @@ runs:
         # (.review.yaml, CLAUDE.md, codegraph repo_root) target the
         # CONSUMER repo, not the action repo. `pip install -e .` already
         # made the `src` package importable from anywhere.
-        python -m src ${{ inputs.mode }}
+        #
+        # -P (PEP 668 / Python 3.11+) tells the interpreter NOT to prepend
+        # the CWD to sys.path. Without this, a consumer repo that happens
+        # to have its own top-level `src/` directory (very common) shadows
+        # our editable-installed `src` package and `-m src` fails with
+        # "'src' is a package and cannot be directly executed".
+        python -P -m src ${{ inputs.mode }}

--- a/ai-review-v2/action.yml
+++ b/ai-review-v2/action.yml
@@ -119,6 +119,11 @@ runs:
       shell: bash
       working-directory: ${{ github.workspace }}
       env:
+        # Make `src/` importable from anywhere without relying on
+        # pip's editable-install autodiscovery (which pyproject.toml
+        # doesn't fully configure). Combined with -P this guarantees:
+        # consumer src/ in CWD won't shadow, our src/ is found via PYTHONPATH.
+        PYTHONPATH: ${{ github.action_path }}
         REVIEW_API_KEY: ${{ inputs.review-api-key }}
         REVIEW_BASE_URL: ${{ inputs.review-base-url }}
         REVIEW_MODEL: ${{ inputs.review-model }}

--- a/ai-review-v2/action.yml
+++ b/ai-review-v2/action.yml
@@ -119,11 +119,6 @@ runs:
       shell: bash
       working-directory: ${{ github.workspace }}
       env:
-        # Make `src/` importable from anywhere without relying on
-        # pip's editable-install autodiscovery (which pyproject.toml
-        # doesn't fully configure). Combined with -P this guarantees:
-        # consumer src/ in CWD won't shadow, our src/ is found via PYTHONPATH.
-        PYTHONPATH: ${{ github.action_path }}
         REVIEW_API_KEY: ${{ inputs.review-api-key }}
         REVIEW_BASE_URL: ${{ inputs.review-base-url }}
         REVIEW_MODEL: ${{ inputs.review-model }}
@@ -148,15 +143,14 @@ runs:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       run: |
-        # IMPORTANT: stay in the consumer repo (github.workspace) so that
-        # `git show <sha>:<path>` and other relative-path lookups
-        # (.review.yaml, CLAUDE.md, codegraph repo_root) target the
-        # CONSUMER repo, not the action repo. `pip install -e .` already
-        # made the `src` package importable from anywhere.
+        # Stay in the consumer repo (github.workspace) so `git show <sha>:<path>`
+        # and other relative-path lookups (.review.yaml, CLAUDE.md, codegraph
+        # repo_root) target the CONSUMER repo, not the action repo. pyproject.toml
+        # is configured to expose the `src` package via setuptools so a plain
+        # editable install handles importability with no PYTHONPATH gymnastics.
         #
-        # -P (PEP 668 / Python 3.11+) tells the interpreter NOT to prepend
-        # the CWD to sys.path. Without this, a consumer repo that happens
-        # to have its own top-level `src/` directory (very common) shadows
-        # our editable-installed `src` package and `-m src` fails with
-        # "'src' is a package and cannot be directly executed".
+        # -P (Python 3.11+) tells the interpreter NOT to prepend CWD to sys.path.
+        # Without this, a consumer repo that happens to have its own top-level
+        # `src/` directory (very common) shadows our installed `src` package and
+        # `-m src` fails with "'src' is a package and cannot be directly executed".
         python -P -m src ${{ inputs.mode }}

--- a/ai-review-v2/action.yml
+++ b/ai-review-v2/action.yml
@@ -68,6 +68,10 @@ inputs:
     description: 'Orphan branch name where the SQLite DB is persisted'
     required: false
     default: '__reviewer_state__'
+  force-depth:
+    description: "Override triage decision: 'light' | 'standard' | 'deep'. Empty = let triage decide. Useful for evaluation runs or high-risk PRs."
+    required: false
+    default: ''
 
   github-token:
     description: 'Token with contents:write (for state branch) and pull-requests:write'
@@ -131,6 +135,7 @@ runs:
         ENABLE_LEARNINGS: ${{ inputs.enable-learnings }}
         ENABLE_INCREMENTAL: ${{ inputs.enable-incremental }}
         STATE_BRANCH: ${{ inputs.state-branch }}
+        FORCE_DEPTH: ${{ inputs.force-depth }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
         GH_TOKEN: ${{ inputs.github-token }}
         GITHUB_REPOSITORY: ${{ github.repository }}

--- a/ai-review-v2/action.yml
+++ b/ai-review-v2/action.yml
@@ -143,5 +143,9 @@ runs:
         BASE_SHA: ${{ github.event.pull_request.base.sha }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
       run: |
-        cd ${{ github.action_path }}
+        # IMPORTANT: stay in the consumer repo (github.workspace) so that
+        # `git show <sha>:<path>` and other relative-path lookups
+        # (.review.yaml, CLAUDE.md, codegraph repo_root) target the
+        # CONSUMER repo, not the action repo. `pip install -e .` already
+        # made the `src` package importable from anywhere.
         python -m src ${{ inputs.mode }}

--- a/ai-review-v2/pyproject.toml
+++ b/ai-review-v2/pyproject.toml
@@ -34,6 +34,17 @@ dev = [
 [project.scripts]
 pr-reviewer = "src.__main__:cli"
 
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+# Make `pip install -e .` discover the src/ package without relying on
+# auto-detection (which silently does nothing for un-prefixed src layouts
+# and would leave the package un-importable except via PYTHONPATH).
+where = ["."]
+include = ["src*"]
+
 [tool.ruff]
 line-length = 110
 target-version = "py311"

--- a/ai-review-v2/pyproject.toml
+++ b/ai-review-v2/pyproject.toml
@@ -1,0 +1,43 @@
+[project]
+name = "pr-reviewer"
+version = "2.0.0"
+description = "LLM-agnostic AI PR reviewer with codegraph, learnings, and incremental state."
+requires-python = ">=3.11"
+dependencies = [
+    # LLM client (works against any OpenAI-compatible /v1 endpoint)
+    "openai>=1.40",
+
+    # Code parsing for the symbol/reference index
+    "tree-sitter==0.21.3",
+    "tree-sitter-languages==1.10.2",
+
+    # Vector search inside SQLite (no Postgres, no Chroma)
+    "sqlite-vec>=0.1.6",
+
+    # Config + small utilities
+    "PyYAML>=6.0",
+    "pathspec>=0.12",         # gitignore-style glob matching for path instructions
+    "tenacity>=8.2",          # retries with backoff
+
+    # Static analyzers (run as subprocesses; failures are tolerated)
+    "ruff>=0.6",
+    "bandit>=1.7",
+    "semgrep>=1.80",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-cov",
+]
+
+[project.scripts]
+pr-reviewer = "src.__main__:cli"
+
+[tool.ruff]
+line-length = 110
+target-version = "py311"
+
+[tool.ruff.lint]
+extend-select = ["I", "UP", "B", "SIM"]
+ignore = ["E501"]  # line length handled by formatter

--- a/ai-review-v2/schema.sql
+++ b/ai-review-v2/schema.sql
@@ -1,0 +1,114 @@
+-- pr-reviewer state schema. Lives on the __reviewer_state__ orphan branch.
+--
+-- All tables are explicitly versioned. The `schema_version` table tracks the
+-- current migration level so future versions can ALTER safely.
+--
+-- The vec0 virtual table requires the sqlite-vec extension loaded at connect time
+-- (see knowledge.py::connect).
+
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+PRAGMA synchronous = NORMAL;
+
+CREATE TABLE IF NOT EXISTS schema_version (
+    version  INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+INSERT OR IGNORE INTO schema_version (version) VALUES (1);
+
+-- ============================================================
+-- LEARNINGS
+-- Natural-language preferences extracted from @-mention replies on PR comments.
+-- Loaded into review prompts via vector similarity at review time.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS learnings (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    description     TEXT    NOT NULL,             -- the learning text itself
+    scope           TEXT    NOT NULL DEFAULT 'repo',  -- 'repo' | 'org' | 'global'
+    file_pattern    TEXT,                         -- optional gitignore-style glob
+    repo            TEXT    NOT NULL,             -- owner/name
+    source_pr       INTEGER,                      -- PR number that produced this
+    source_comment  INTEGER,                      -- GitHub comment id
+    created_by      TEXT    NOT NULL,             -- GitHub login
+    created_at      TEXT    NOT NULL DEFAULT (datetime('now')),
+    last_used_at    TEXT,
+    usage_count     INTEGER NOT NULL DEFAULT 0,
+    active          INTEGER NOT NULL DEFAULT 1    -- soft-delete via UPDATE
+);
+
+CREATE INDEX IF NOT EXISTS idx_learnings_repo ON learnings(repo, active);
+CREATE INDEX IF NOT EXISTS idx_learnings_scope ON learnings(scope, active);
+
+-- Vector index (sqlite-vec). Dimension matches the configured embedding model.
+-- 1536 is text-embedding-3-small; override in knowledge.py if you switch models.
+CREATE VIRTUAL TABLE IF NOT EXISTS learnings_vec USING vec0(
+    learning_id INTEGER PRIMARY KEY,
+    embedding   FLOAT[1536]
+);
+
+-- ============================================================
+-- REVIEW STATE
+-- Per-PR record of what we've already reviewed, so re-pushes don't re-flag everything.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS reviewed_prs (
+    repo            TEXT    NOT NULL,
+    pr_number       INTEGER NOT NULL,
+    last_head_sha   TEXT    NOT NULL,
+    last_review_id  INTEGER,                       -- GitHub review id (idempotency)
+    reviewed_at     TEXT    NOT NULL DEFAULT (datetime('now')),
+    triage_depth    TEXT,                          -- skip|light|standard|deep
+    findings_count  INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (repo, pr_number)
+);
+
+-- Per-file SHA hash at last review. On re-push, we diff against this to
+-- find which files actually changed since we last looked.
+CREATE TABLE IF NOT EXISTS reviewed_files (
+    repo        TEXT    NOT NULL,
+    pr_number   INTEGER NOT NULL,
+    path        TEXT    NOT NULL,
+    blob_sha    TEXT    NOT NULL,                  -- git blob sha at last review
+    reviewed_at TEXT    NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (repo, pr_number, path),
+    FOREIGN KEY (repo, pr_number) REFERENCES reviewed_prs(repo, pr_number) ON DELETE CASCADE
+);
+
+-- ============================================================
+-- CODEGRAPH CACHE
+-- File-level symbol index. Re-parsed only when the file's content_sha changes.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS file_symbols (
+    repo        TEXT NOT NULL,
+    path        TEXT NOT NULL,
+    content_sha TEXT NOT NULL,
+    language    TEXT NOT NULL,
+    -- JSON array of {name, kind, start_line, end_line, signature}
+    symbols     TEXT NOT NULL,
+    cached_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (repo, path)
+);
+
+CREATE INDEX IF NOT EXISTS idx_file_symbols_lang ON file_symbols(repo, language);
+
+-- ============================================================
+-- COST / OBSERVABILITY (lightweight)
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS llm_calls (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    repo            TEXT NOT NULL,
+    pr_number       INTEGER,
+    stage           TEXT NOT NULL,            -- triage|summary|file_review|cross_cut|learning_extract
+    model           TEXT NOT NULL,
+    prompt_tokens   INTEGER,
+    completion_tokens INTEGER,
+    duration_ms     INTEGER,
+    succeeded       INTEGER NOT NULL,
+    error           TEXT,
+    created_at      TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_llm_calls_pr ON llm_calls(repo, pr_number, created_at);

--- a/ai-review-v2/src/__init__.py
+++ b/ai-review-v2/src/__init__.py
@@ -1,0 +1,3 @@
+"""pr-reviewer: LLM-agnostic AI PR reviewer with codegraph, learnings, and incremental state."""
+
+__version__ = "2.0.0"

--- a/ai-review-v2/src/__main__.py
+++ b/ai-review-v2/src/__main__.py
@@ -1,0 +1,59 @@
+"""Entry point.
+
+Two modes:
+  python -m src review    → run the PR review pipeline
+  python -m src learn     → process an issue_comment event for learnings
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from . import config, github_api, knowledge, learn, orchestrator
+
+
+def cli() -> int:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    log = logging.getLogger("pr-reviewer")
+
+    args = sys.argv[1:]
+    mode = args[0] if args else "review"
+
+    cfg = config.load()
+    log.info("mode=%s repo=%s pr=%s", mode, cfg.github_repo, cfg.pr_number)
+
+    branch = github_api.StateBranch(
+        cfg.github_repo, cfg.state_branch, cfg.state_dir, cfg.github_token,
+    )
+    branch.setup()
+
+    try:
+        with knowledge.connect(branch.db_path) as conn:
+            if mode == "review":
+                orchestrator.review_pr(cfg, conn)
+            elif mode == "learn":
+                import json
+                import os
+                event_path = os.environ.get("GITHUB_EVENT_PATH")
+                if not event_path or not os.path.exists(event_path):
+                    log.error("learn mode requires GITHUB_EVENT_PATH")
+                    return 1
+                with open(event_path) as f:
+                    event = json.load(f)
+                learn.process_comment_event(cfg, conn, event)
+            else:
+                log.error("Unknown mode: %s (use 'review' or 'learn')", mode)
+                return 2
+    finally:
+        branch.commit_and_push(f"update: state after {mode} on PR #{cfg.pr_number}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(cli())

--- a/ai-review-v2/src/analyzers.py
+++ b/ai-review-v2/src/analyzers.py
@@ -1,0 +1,163 @@
+"""Static analyzers. Run language-appropriate tools and attach per-file output.
+
+Philosophy: analyzers are advisory and tolerant. If a tool isn't installed
+or fails, we silently skip it and tell the LLM "(not analyzed)". The review
+prompt explicitly instructs the model not to re-flag anything the analyzers
+caught — this is the noise-reduction half of the pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+
+from .github_api import ChangedFile
+
+log = logging.getLogger(__name__)
+
+
+def run_all(files: list[ChangedFile]) -> None:
+    by_lang: dict[str, list[ChangedFile]] = {}
+    for f in files:
+        if f.status == "removed" or not f.new_content:
+            continue
+        if f.language:
+            by_lang.setdefault(f.language, []).append(f)
+
+    if by_lang.get("python"):
+        _python(by_lang["python"])
+    js_like = by_lang.get("javascript", []) + by_lang.get("typescript", []) + by_lang.get("tsx", [])
+    if js_like:
+        _javascript(js_like)
+    if by_lang.get("go"):
+        _go(by_lang["go"])
+    if by_lang.get("rust"):
+        _rust(by_lang["rust"])
+
+    # Semgrep + secrets scan across everything
+    _semgrep(files)
+    _gitleaks(files)
+
+
+# ============================================================
+# RUNNERS
+# ============================================================
+
+def _run(cmd: list[str], timeout: int = 120) -> str:
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return (r.stdout + ("\n" + r.stderr if r.stderr else "")).strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        log.debug("analyzer %s skipped: %s", cmd[0], e)
+        return ""
+
+
+def _python(files: list[ChangedFile]) -> None:
+    paths = [f.path for f in files]
+    out_by_tool: dict[str, str] = {
+        "ruff":   _run(["ruff", "check", "--output-format=concise", *paths]),
+        "bandit": _run(["bandit", "-q", "-f", "txt", *paths], timeout=90),
+    }
+    if Path("pyproject.toml").exists() or Path("mypy.ini").exists():
+        out_by_tool["mypy"] = _run(
+            ["mypy", "--no-error-summary", "--no-color-output", *paths], timeout=90
+        )
+    _distribute(files, out_by_tool)
+
+
+def _javascript(files: list[ChangedFile]) -> None:
+    if not Path("package.json").exists():
+        return
+    paths = [f.path for f in files]
+    eslint = Path("node_modules/.bin/eslint")
+    if eslint.exists():
+        out = _run([str(eslint), "--format", "compact", *paths], timeout=120)
+        _distribute(files, {"eslint": out})
+
+
+def _go(files: list[ChangedFile]) -> None:
+    pkgs = sorted({"./" + str(Path(f.path).parent) for f in files if "/" in f.path})
+    pkgs = [p for p in pkgs if p != "./."]
+    if not pkgs:
+        return
+    out = _run(["go", "vet", *pkgs], timeout=120)
+    _distribute(files, {"go vet": out})
+
+
+def _rust(files: list[ChangedFile]) -> None:
+    if not Path("Cargo.toml").exists():
+        return
+    out = _run(["cargo", "clippy", "--message-format=short", "--no-deps"], timeout=180)
+    _distribute(files, {"clippy": out})
+
+
+def _semgrep(files: list[ChangedFile]) -> None:
+    paths = [f.path for f in files if f.status != "removed"]
+    if not paths:
+        return
+    out = _run(
+        ["semgrep", "--config=auto", "--quiet", "--json", "--timeout=60", *paths],
+        timeout=180,
+    )
+    if not out:
+        return
+    try:
+        data = json.loads(out)
+    except json.JSONDecodeError:
+        return
+
+    by_path: dict[str, list[str]] = {}
+    for r in data.get("results", []):
+        check = r["check_id"].rsplit(".", 1)[-1]
+        msg = r["extra"]["message"][:200]
+        by_path.setdefault(r["path"], []).append(f"  L{r['start']['line']}: [{check}] {msg}")
+
+    for f in files:
+        if f.path in by_path:
+            f.analyzer_output += "\nsemgrep:\n" + "\n".join(by_path[f.path][:20])
+
+
+def _gitleaks(files: list[ChangedFile]) -> None:
+    out = _run(
+        ["gitleaks", "detect", "--no-banner", "--redact", "--report-format=json"],
+        timeout=60,
+    )
+    if out and out.startswith("[") and "findings" not in out.lower():
+        try:
+            findings = json.loads(out)
+        except json.JSONDecodeError:
+            return
+        if not findings:
+            return
+        # gitleaks reports per file path
+        by_path: dict[str, list[str]] = {}
+        for fnd in findings:
+            path = fnd.get("File")
+            line = fnd.get("StartLine")
+            rule = fnd.get("RuleID")
+            if path:
+                by_path.setdefault(path, []).append(f"  L{line}: [{rule}] potential secret")
+        for f in files:
+            if f.path in by_path:
+                f.analyzer_output += "\ngitleaks:\n" + "\n".join(by_path[f.path])
+
+
+# ============================================================
+# DISTRIBUTION
+# ============================================================
+
+def _distribute(files: list[ChangedFile], outputs: dict[str, str]) -> None:
+    for tool, raw in outputs.items():
+        if not raw.strip():
+            continue
+        by_path: dict[str, list[str]] = {}
+        for line in raw.splitlines():
+            for f in files:
+                if line.startswith(f.path) or f":{f.path}" in line:
+                    by_path.setdefault(f.path, []).append("  " + line)
+                    break
+        for f in files:
+            if f.path in by_path:
+                f.analyzer_output += f"\n{tool}:\n" + "\n".join(by_path[f.path][:30])

--- a/ai-review-v2/src/codegraph.py
+++ b/ai-review-v2/src/codegraph.py
@@ -1,0 +1,371 @@
+"""Codegraph: tree-sitter symbol extraction + ripgrep-based reference finding.
+
+Two responsibilities:
+  1. For each changed file, extract function/class/method definitions via tree-sitter.
+     Symbol index is cached in SQLite keyed by content_sha.
+  2. For each *touched* symbol (i.e. a definition that overlaps the diff hunks),
+     find call sites in OTHER files via ripgrep + tree-sitter validation.
+
+The output is a per-changed-file "callers context block" that gets injected into
+the review prompt. This is the single biggest quality unlock over diff-only review.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import sqlite3
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from tree_sitter_languages import get_language, get_parser
+
+from . import knowledge
+
+log = logging.getLogger(__name__)
+
+
+# Languages we support. Adding a new one: pick a tree-sitter grammar name and
+# write a query that captures function/class definitions.
+SUPPORTED_LANGUAGES: dict[str, str] = {
+    "python":     "python",
+    "javascript": "javascript",
+    "typescript": "typescript",
+    "tsx":        "tsx",
+    "go":         "go",
+    "rust":       "rust",
+    "java":       "java",
+    "ruby":       "ruby",
+}
+
+# Tree-sitter queries: capture the name of definitions per language.
+# We deliberately keep these minimal — name + range is what we need.
+_QUERIES: dict[str, str] = {
+    "python": """
+        (function_definition name: (identifier) @name)
+        (class_definition name: (identifier) @name)
+    """,
+    "javascript": """
+        (function_declaration name: (identifier) @name)
+        (method_definition name: (property_identifier) @name)
+        (class_declaration name: (identifier) @name)
+        (variable_declarator name: (identifier) @name value: (arrow_function))
+        (variable_declarator name: (identifier) @name value: (function))
+    """,
+    "typescript": """
+        (function_declaration name: (identifier) @name)
+        (method_definition name: (property_identifier) @name)
+        (class_declaration name: (type_identifier) @name)
+        (interface_declaration name: (type_identifier) @name)
+        (type_alias_declaration name: (type_identifier) @name)
+    """,
+    "tsx": """
+        (function_declaration name: (identifier) @name)
+        (method_definition name: (property_identifier) @name)
+        (class_declaration name: (type_identifier) @name)
+    """,
+    "go": """
+        (function_declaration name: (identifier) @name)
+        (method_declaration name: (field_identifier) @name)
+        (type_declaration (type_spec name: (type_identifier) @name))
+    """,
+    "rust": """
+        (function_item name: (identifier) @name)
+        (struct_item name: (type_identifier) @name)
+        (impl_item type: (type_identifier) @name)
+        (trait_item name: (type_identifier) @name)
+    """,
+    "java": """
+        (method_declaration name: (identifier) @name)
+        (class_declaration name: (identifier) @name)
+        (interface_declaration name: (identifier) @name)
+    """,
+    "ruby": """
+        (method name: (identifier) @name)
+        (class name: (constant) @name)
+        (module name: (constant) @name)
+    """,
+}
+
+
+@dataclass
+class Symbol:
+    name: str
+    kind: str          # 'function' | 'class' | 'method' (we infer from query node type)
+    start_line: int    # 1-based
+    end_line: int
+    signature: str     # the first line of the definition, trimmed
+
+
+@dataclass
+class CallerSnippet:
+    file: str
+    line: int
+    context: str       # ±3 lines around the call
+
+
+@dataclass
+class CodegraphContext:
+    """What gets injected into the per-file review prompt for one file."""
+    touched_symbols: list[Symbol] = field(default_factory=list)
+    callers_by_symbol: dict[str, list[CallerSnippet]] = field(default_factory=dict)
+
+    def render(self) -> str:
+        if not self.touched_symbols:
+            return ""
+        parts = ["EXTERNAL CALLERS OF MODIFIED SYMBOLS:"]
+        for sym in self.touched_symbols:
+            callers = self.callers_by_symbol.get(sym.name, [])
+            if not callers:
+                continue
+            parts.append(f"\n  {sym.kind} {sym.name} (L{sym.start_line}-{sym.end_line})")
+            for c in callers[:5]:
+                snippet = "\n      ".join(c.context.splitlines())
+                parts.append(f"    called at {c.file}:{c.line}")
+                parts.append(f"      {snippet}")
+        return "\n".join(parts) if len(parts) > 1 else ""
+
+
+# ============================================================
+# SYMBOL EXTRACTION
+# ============================================================
+
+def extract_symbols(content: str, language: str) -> list[Symbol]:
+    if language not in SUPPORTED_LANGUAGES:
+        return []
+    ts_lang = SUPPORTED_LANGUAGES[language]
+    if ts_lang not in _QUERIES:
+        return []
+    try:
+        parser = get_parser(ts_lang)
+        lang = get_language(ts_lang)
+        tree = parser.parse(content.encode("utf-8", errors="replace"))
+    except Exception as e:
+        log.debug("tree-sitter parse failed for language=%s: %s", language, e)
+        return []
+
+    try:
+        query = lang.query(_QUERIES[ts_lang])
+        captures = query.captures(tree.root_node)
+    except Exception as e:
+        log.debug("tree-sitter query failed for language=%s: %s", language, e)
+        return []
+
+    symbols: list[Symbol] = []
+    lines = content.splitlines()
+    for node, _capture_name in captures:
+        # The captured node is the @name identifier; its parent is the definition.
+        parent = node.parent
+        if parent is None:
+            continue
+        start_line = parent.start_point[0] + 1
+        end_line = parent.end_point[0] + 1
+        try:
+            name = node.text.decode("utf-8", errors="replace")
+        except Exception:
+            continue
+        # First line, trimmed, as a usable signature
+        signature = lines[start_line - 1].strip() if 0 <= start_line - 1 < len(lines) else ""
+        kind = _classify(parent.type)
+        symbols.append(Symbol(name=name, kind=kind, start_line=start_line, end_line=end_line, signature=signature))
+    return symbols
+
+
+def _classify(node_type: str) -> str:
+    if "class" in node_type:
+        return "class"
+    if "interface" in node_type or "trait" in node_type:
+        return "interface"
+    if "method" in node_type:
+        return "method"
+    if "function" in node_type or "func" in node_type:
+        return "function"
+    if "type" in node_type or "struct" in node_type:
+        return "type"
+    return "symbol"
+
+
+def get_or_extract_symbols(
+    conn: sqlite3.Connection,
+    repo: str,
+    path: str,
+    content: str,
+    language: str,
+) -> list[Symbol]:
+    """Cached symbol extraction. Re-parses only when content_sha changes."""
+    sha = knowledge.content_sha(content)
+    cached = knowledge.get_cached_symbols(conn, repo, path, sha)
+    if cached is not None:
+        return [Symbol(**s) for s in cached]
+    symbols = extract_symbols(content, language)
+    knowledge.cache_symbols(
+        conn, repo, path, sha, language, [s.__dict__ for s in symbols]
+    )
+    return symbols
+
+
+# ============================================================
+# REFERENCE FINDING (ripgrep)
+# ============================================================
+
+def find_callers(
+    symbol_name: str,
+    own_file: str,
+    *,
+    repo_root: str = ".",
+    languages: set[str] | None = None,
+    max_results: int = 8,
+) -> list[CallerSnippet]:
+    """ripgrep for `symbol_name(` across the repo, excluding the defining file.
+
+    We deliberately keep this textual + cheap. Tree-sitter validation per-hit
+    would be more precise but ~10x slower; the LLM tolerates the noise fine.
+    """
+    if not shutil.which("rg"):
+        log.debug("ripgrep not installed; skipping caller search")
+        return []
+
+    # Word-boundary match before the symbol; helps avoid substring hits.
+    # We allow `.symbol(`, `symbol(`, `<symbol(` etc.
+    pattern = rf"\b{symbol_name}\s*\("
+
+    cmd = [
+        "rg", "--no-heading", "--line-number", "--context", "2",
+        "--max-count", str(max_results), "--max-filesize", "500K",
+        "-e", pattern, repo_root,
+    ]
+    if languages:
+        for lang in languages:
+            cmd += ["--type", _rg_type(lang)]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=20)
+    except subprocess.TimeoutExpired:
+        log.debug("rg timeout looking for %s", symbol_name)
+        return []
+
+    if proc.returncode not in (0, 1):  # 1 = no matches
+        log.debug("rg failed for %s: %s", symbol_name, proc.stderr[:200])
+        return []
+
+    return _parse_rg_output(proc.stdout, own_file=own_file, max_results=max_results)
+
+
+def _rg_type(lang: str) -> str:
+    return {
+        "python": "py", "javascript": "js", "typescript": "ts", "tsx": "ts",
+        "go": "go", "rust": "rust", "java": "java", "ruby": "ruby",
+    }.get(lang, lang)
+
+
+def _parse_rg_output(stdout: str, *, own_file: str, max_results: int) -> list[CallerSnippet]:
+    """Parse `rg --context 2` output into CallerSnippets, one per matched line.
+
+    rg context output looks like:
+        path/file.py-5-def caller():
+        path/file.py-6-    setup()
+        path/file.py:7:    do_thing(arg)
+        path/file.py-8-    teardown()
+        --
+    Lines with `:` are matches; lines with `-` are context.
+    """
+    own_norm = str(Path(own_file)).lstrip("./")
+    blocks: list[list[str]] = []
+    cur: list[str] = []
+    for line in stdout.splitlines():
+        if line == "--":
+            if cur:
+                blocks.append(cur)
+                cur = []
+        else:
+            cur.append(line)
+    if cur:
+        blocks.append(cur)
+
+    results: list[CallerSnippet] = []
+    for block in blocks:
+        match_line = None
+        match_lineno = 0
+        match_file = ""
+        ctx_lines: list[str] = []
+        for raw in block:
+            # rg uses ':' for the match line, '-' for context. The first separator
+            # after the path tells us which it is.
+            # Format: path<sep>lineno<sep>text
+            parts = raw.split(":", 2)
+            if len(parts) == 3 and parts[1].isdigit():
+                match_file = parts[0]
+                match_lineno = int(parts[1])
+                match_line = parts[2]
+                ctx_lines.append(parts[2])
+            else:
+                parts = raw.split("-", 2)
+                if len(parts) == 3 and parts[1].isdigit():
+                    if not match_file:
+                        match_file = parts[0]
+                    ctx_lines.append(parts[2])
+
+        if not match_line or not match_file:
+            continue
+        norm = str(Path(match_file)).lstrip("./")
+        if norm == own_norm:
+            continue
+        results.append(CallerSnippet(
+            file=match_file,
+            line=match_lineno,
+            context="\n".join(ctx_lines),
+        ))
+        if len(results) >= max_results:
+            break
+    return results
+
+
+# ============================================================
+# TOP-LEVEL: build context for a single changed file
+# ============================================================
+
+def build_context_for_file(
+    conn: sqlite3.Connection,
+    *,
+    repo: str,
+    path: str,
+    content: str,
+    language: str,
+    diff_line_numbers: set[int],
+    repo_root: str = ".",
+) -> CodegraphContext:
+    """For a changed file, compute the codegraph context block.
+
+    Steps:
+      1. Extract (or load cached) symbols from the new file content.
+      2. Identify which symbols overlap the changed line range (touched_symbols).
+      3. For each touched symbol, ripgrep the repo for callers.
+    """
+    ctx = CodegraphContext()
+    if not language or language not in SUPPORTED_LANGUAGES:
+        return ctx
+
+    symbols = get_or_extract_symbols(conn, repo, path, content, language)
+    if not symbols:
+        return ctx
+
+    # Symbols whose body overlaps diff lines are "touched"
+    touched: list[Symbol] = []
+    for sym in symbols:
+        if any(sym.start_line <= ln <= sym.end_line for ln in diff_line_numbers):
+            touched.append(sym)
+    # Cap at 6 to keep the prompt bounded
+    ctx.touched_symbols = touched[:6]
+
+    for sym in ctx.touched_symbols:
+        callers = find_callers(
+            sym.name,
+            own_file=path,
+            repo_root=repo_root,
+            languages={language},
+            max_results=5,
+        )
+        if callers:
+            ctx.callers_by_symbol[sym.name] = callers
+
+    return ctx

--- a/ai-review-v2/src/config.py
+++ b/ai-review-v2/src/config.py
@@ -1,0 +1,173 @@
+"""Configuration loading and validation.
+
+Three layers, merged in order of precedence (later wins):
+  1. Sensible built-in defaults
+  2. .review.yaml at the repo root (if present)
+  3. Environment variables (set by action.yml from action inputs)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class LLMEndpoint:
+    base_url: str
+    model: str
+    api_key: str
+
+    def __post_init__(self):
+        if not self.api_key:
+            raise ValueError(f"Missing API key for model {self.model}")
+
+
+@dataclass
+class PathInstruction:
+    pattern: str               # gitignore-style glob, e.g. "src/api/**"
+    instructions: str          # natural-language guidance for matching files
+
+
+@dataclass
+class Config:
+    # LLM endpoints
+    review:    LLMEndpoint
+    triage:    LLMEndpoint
+    embedding: LLMEndpoint
+    embedding_dimensions: int = 1536
+
+    # GitHub
+    github_token: str = ""
+    github_repo:  str = ""
+    pr_number:    int = 0
+    base_sha:     str = ""
+    head_sha:     str = ""
+
+    # State branch (where we keep the SQLite DB)
+    state_branch: str = "__reviewer_state__"
+    state_dir:    str = "/tmp/reviewer-state"
+
+    # Behavior
+    max_files: int = 50
+    max_file_bytes: int = 100_000
+    confidence_threshold: int = 3
+    enable_analyzers: bool = True
+    enable_codegraph: bool = True
+    enable_learnings: bool = True
+    enable_incremental: bool = True
+    parallel_file_reviews: int = 6
+
+    # Path-based review instructions
+    path_instructions: list[PathInstruction] = field(default_factory=list)
+
+    # Files to skip entirely
+    skip_patterns: list[str] = field(default_factory=lambda: [
+        "package-lock.json", "yarn.lock", "pnpm-lock.yaml", "poetry.lock",
+        "Cargo.lock", "go.sum", "Pipfile.lock", "composer.lock", "Gemfile.lock",
+        "node_modules/**", "vendor/**", "dist/**", "build/**", ".next/**",
+        "**/__generated__/**", "**/*.min.js", "**/*.min.css",
+    ])
+
+    # Bot identity (used by the learnings listener to detect @-mentions)
+    bot_username: str = "github-actions[bot]"
+
+
+def load() -> Config:
+    """Build a Config from environment + .review.yaml."""
+    yaml_data = _load_yaml(".review.yaml")
+
+    def env_or_yaml(env_key: str, yaml_path: list[str], default: Any = None) -> Any:
+        if v := os.environ.get(env_key):
+            return v
+        d = yaml_data
+        for k in yaml_path:
+            if not isinstance(d, dict) or k not in d:
+                return default
+            d = d[k]
+        return d if d is not None else default
+
+    # ---- LLM endpoints ----
+    review_url = env_or_yaml("REVIEW_BASE_URL", ["review", "base_url"], "https://api.openai.com/v1")
+    review_key = os.environ["REVIEW_API_KEY"]  # required, no fallback
+    review_model = env_or_yaml("REVIEW_MODEL", ["review", "model"], "gpt-4o")
+
+    triage = LLMEndpoint(
+        base_url=env_or_yaml("TRIAGE_BASE_URL", ["triage", "base_url"], review_url),
+        api_key=os.environ.get("TRIAGE_API_KEY", review_key),
+        model=env_or_yaml("TRIAGE_MODEL", ["triage", "model"], "gpt-4o-mini"),
+    )
+    review = LLMEndpoint(base_url=review_url, api_key=review_key, model=review_model)
+    embedding = LLMEndpoint(
+        base_url=env_or_yaml("EMBED_BASE_URL", ["embedding", "base_url"], review_url),
+        api_key=os.environ.get("EMBED_API_KEY", review_key),
+        model=env_or_yaml("EMBED_MODEL", ["embedding", "model"], "text-embedding-3-small"),
+    )
+
+    cfg = Config(
+        review=review,
+        triage=triage,
+        embedding=embedding,
+        embedding_dimensions=int(env_or_yaml("EMBED_DIMENSIONS", ["embedding", "dimensions"], 1536)),
+        github_token=os.environ.get("GITHUB_TOKEN", ""),
+        github_repo=os.environ.get("GITHUB_REPOSITORY", ""),
+        pr_number=int(os.environ.get("PR_NUMBER", "0") or 0),
+        base_sha=os.environ.get("BASE_SHA", ""),
+        head_sha=os.environ.get("HEAD_SHA", ""),
+        state_branch=env_or_yaml("STATE_BRANCH", ["state", "branch"], "__reviewer_state__"),
+        state_dir=env_or_yaml("STATE_DIR", ["state", "dir"], "/tmp/reviewer-state"),
+        max_files=int(env_or_yaml("MAX_FILES", ["limits", "max_files"], 50)),
+        max_file_bytes=int(env_or_yaml("MAX_FILE_BYTES", ["limits", "max_file_bytes"], 100_000)),
+        confidence_threshold=int(env_or_yaml("CONFIDENCE_THRESHOLD", ["limits", "confidence"], 3)),
+        enable_analyzers=_to_bool(env_or_yaml("ENABLE_ANALYZERS", ["features", "analyzers"], True)),
+        enable_codegraph=_to_bool(env_or_yaml("ENABLE_CODEGRAPH", ["features", "codegraph"], True)),
+        enable_learnings=_to_bool(env_or_yaml("ENABLE_LEARNINGS", ["features", "learnings"], True)),
+        enable_incremental=_to_bool(env_or_yaml("ENABLE_INCREMENTAL", ["features", "incremental"], True)),
+        parallel_file_reviews=int(env_or_yaml("PARALLEL_FILE_REVIEWS", ["limits", "parallel"], 6)),
+        bot_username=env_or_yaml("BOT_USERNAME", ["bot_username"], "github-actions[bot]"),
+    )
+
+    # Path instructions only come from yaml (would be awkward as env)
+    pi = yaml_data.get("path_instructions") or []
+    cfg.path_instructions = [
+        PathInstruction(pattern=p["pattern"], instructions=p["instructions"])
+        for p in pi if "pattern" in p and "instructions" in p
+    ]
+
+    # Custom skip patterns extend defaults
+    custom_skips = yaml_data.get("skip_patterns") or []
+    if custom_skips:
+        cfg.skip_patterns = cfg.skip_patterns + list(custom_skips)
+
+    return cfg
+
+
+def _load_yaml(path: str) -> dict:
+    p = Path(path)
+    if not p.exists():
+        return {}
+    try:
+        with p.open() as f:
+            data = yaml.safe_load(f) or {}
+        if not isinstance(data, dict):
+            log.warning("%s is not a mapping at root; ignoring", path)
+            return {}
+        return data
+    except Exception as e:
+        log.warning("Failed to parse %s: %s", path, e)
+        return {}
+
+
+def _to_bool(v: Any) -> bool:
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        return v.lower() in ("1", "true", "yes", "on")
+    return bool(v)

--- a/ai-review-v2/src/config.py
+++ b/ai-review-v2/src/config.py
@@ -101,13 +101,13 @@ def load() -> Config:
 
     triage = LLMEndpoint(
         base_url=env_or_yaml("TRIAGE_BASE_URL", ["triage", "base_url"], review_url),
-        api_key=os.environ.get("TRIAGE_API_KEY", review_key),
+        api_key=os.environ.get("TRIAGE_API_KEY") or review_key,
         model=env_or_yaml("TRIAGE_MODEL", ["triage", "model"], "gpt-4o-mini"),
     )
     review = LLMEndpoint(base_url=review_url, api_key=review_key, model=review_model)
     embedding = LLMEndpoint(
         base_url=env_or_yaml("EMBED_BASE_URL", ["embedding", "base_url"], review_url),
-        api_key=os.environ.get("EMBED_API_KEY", review_key),
+        api_key=os.environ.get("EMBED_API_KEY") or review_key,
         model=env_or_yaml("EMBED_MODEL", ["embedding", "model"], "text-embedding-3-small"),
     )
 

--- a/ai-review-v2/src/github_api.py
+++ b/ai-review-v2/src/github_api.py
@@ -190,11 +190,29 @@ def post_review(
     inline_comments: list[dict],
     event: str,
 ) -> int | None:
-    """POST /repos/{owner}/{repo}/pulls/{pr}/reviews. Returns the review id."""
+    """POST /repos/{owner}/{repo}/pulls/{pr}/reviews. Returns the review id.
+
+    GitHub's review-with-comments API is fussy: a single bad line/path in any
+    comment fails the whole submission with HTTP 422 and a single inscrutable
+    error string. We try the all-in-one submission first; if it 422s, we retry
+    submitting the summary review without inline comments, then attach the
+    inline findings as standalone review comments one at a time (skipping any
+    individual comment that GitHub still rejects).
+    """
+    return (
+        _try_submit_review(repo, pr_number, head_sha, body, inline_comments, event)
+        or _fallback_split_submit(repo, pr_number, head_sha, body, inline_comments, event)
+    )
+
+
+def _try_submit_review(
+    repo: str, pr_number: int, head_sha: str,
+    body: str, inline_comments: list[dict], event: str,
+) -> int | None:
     payload = {
         "commit_id": head_sha,
         "body": body,
-        "event": event,             # APPROVE | REQUEST_CHANGES | COMMENT
+        "event": event,
         "comments": inline_comments,
     }
     r = subprocess.run(
@@ -205,15 +223,57 @@ def post_review(
         capture_output=True, text=True,
     )
     if r.returncode != 0:
-        log.error("review submit failed: %s", r.stderr.strip()[:500])
-        # Fallback: at least post the summary as a comment so it's not lost
-        gh(["pr", "comment", str(pr_number), "--repo", repo, "--body", body])
+        n = len(inline_comments)
+        log.error(
+            "review submit failed (n_inline=%d): stderr=%s | stdout=%s",
+            n, r.stderr.strip()[:1500], r.stdout.strip()[:1500],
+        )
         return None
     try:
-        data = json.loads(r.stdout)
-        return data.get("id")
+        return json.loads(r.stdout).get("id")
     except Exception:
         return None
+
+
+def _fallback_split_submit(
+    repo: str, pr_number: int, head_sha: str,
+    body: str, inline_comments: list[dict], event: str,
+) -> int | None:
+    """Post the summary review with no comments, then attach each inline as a
+    separate review comment. Slower but resilient to a single bad line."""
+    log.info("Falling back to split submission: summary review + per-comment")
+    review_id = _try_submit_review(repo, pr_number, head_sha, body, [], event)
+    if review_id is None:
+        # Even the summary failed; degrade to a plain PR comment.
+        log.error("Summary review also failed; degrading to plain PR comment")
+        gh(["pr", "comment", str(pr_number), "--repo", repo, "--body", body])
+        return None
+
+    posted = 0
+    for c in inline_comments:
+        payload = {
+            "body": c["body"],
+            "commit_id": head_sha,
+            "path": c["path"],
+            "line": c["line"],
+            "side": c.get("side", "RIGHT"),
+        }
+        r = subprocess.run(
+            ["gh", "api", "--method", "POST",
+             f"repos/{repo}/pulls/{pr_number}/comments",
+             "--input", "-"],
+            input=json.dumps(payload),
+            capture_output=True, text=True,
+        )
+        if r.returncode == 0:
+            posted += 1
+        else:
+            log.warning(
+                "inline comment failed for %s:%s — %s",
+                c.get("path"), c.get("line"), r.stderr.strip()[:300],
+            )
+    log.info("Attached %d/%d inline review comments", posted, len(inline_comments))
+    return review_id
 
 
 def post_pr_comment(repo: str, pr_number: int, body: str) -> None:

--- a/ai-review-v2/src/github_api.py
+++ b/ai-review-v2/src/github_api.py
@@ -198,17 +198,38 @@ def post_review(
     submitting the summary review without inline comments, then attach the
     inline findings as standalone review comments one at a time (skipping any
     individual comment that GitHub still rejects).
+
+    GitHub also forbids APPROVE / REQUEST_CHANGES on a PR opened by the same
+    user as the reviewer (which happens when the bot uses a PAT whose owner
+    also raised the PR). When we detect that specific error we downgrade the
+    event to COMMENT and retry.
     """
-    return (
-        _try_submit_review(repo, pr_number, head_sha, body, inline_comments, event)
-        or _fallback_split_submit(repo, pr_number, head_sha, body, inline_comments, event)
+    rid, downgraded_event = _try_submit_review(
+        repo, pr_number, head_sha, body, inline_comments, event,
     )
+    if rid is not None:
+        return rid
+    return _fallback_split_submit(
+        repo, pr_number, head_sha, body, inline_comments, downgraded_event,
+    )
+
+
+_SELF_REVIEW_ERRORS = (
+    "Can not request changes on your own pull request",
+    "Can not approve your own pull request",
+)
 
 
 def _try_submit_review(
     repo: str, pr_number: int, head_sha: str,
     body: str, inline_comments: list[dict], event: str,
-) -> int | None:
+) -> tuple[int | None, str]:
+    """Submit the review. Returns (review_id_or_None, event_for_retry).
+
+    If GitHub rejects APPROVE/REQUEST_CHANGES because the reviewer is the
+    PR author, retry once with event=COMMENT and surface that downgrade
+    to the caller so the fallback path also uses COMMENT.
+    """
     payload = {
         "commit_id": head_sha,
         "body": body,
@@ -222,17 +243,43 @@ def _try_submit_review(
         input=json.dumps(payload),
         capture_output=True, text=True,
     )
-    if r.returncode != 0:
-        n = len(inline_comments)
-        log.error(
-            "review submit failed (n_inline=%d): stderr=%s | stdout=%s",
-            n, r.stderr.strip()[:1500], r.stdout.strip()[:1500],
+    if r.returncode == 0:
+        try:
+            return json.loads(r.stdout).get("id"), event
+        except Exception:
+            return None, event
+
+    n = len(inline_comments)
+    stdout, stderr = r.stdout.strip()[:1500], r.stderr.strip()[:1500]
+    log.error(
+        "review submit failed (n_inline=%d, event=%s): stderr=%s | stdout=%s",
+        n, event, stderr, stdout,
+    )
+
+    # Self-review on a PR opened by the same user as the token: GitHub
+    # forbids APPROVE / REQUEST_CHANGES. Downgrade to COMMENT and retry.
+    if event != "COMMENT" and any(m in stdout for m in _SELF_REVIEW_ERRORS):
+        log.info("Downgrading event %s → COMMENT (self-PR) and retrying", event)
+        payload["event"] = "COMMENT"
+        r2 = subprocess.run(
+            ["gh", "api", "--method", "POST",
+             f"repos/{repo}/pulls/{pr_number}/reviews",
+             "--input", "-"],
+            input=json.dumps(payload),
+            capture_output=True, text=True,
         )
-        return None
-    try:
-        return json.loads(r.stdout).get("id")
-    except Exception:
-        return None
+        if r2.returncode == 0:
+            try:
+                return json.loads(r2.stdout).get("id"), "COMMENT"
+            except Exception:
+                return None, "COMMENT"
+        log.error(
+            "retry as COMMENT also failed: stderr=%s | stdout=%s",
+            r2.stderr.strip()[:1500], r2.stdout.strip()[:1500],
+        )
+        return None, "COMMENT"
+
+    return None, event
 
 
 def _fallback_split_submit(
@@ -242,7 +289,7 @@ def _fallback_split_submit(
     """Post the summary review with no comments, then attach each inline as a
     separate review comment. Slower but resilient to a single bad line."""
     log.info("Falling back to split submission: summary review + per-comment")
-    review_id = _try_submit_review(repo, pr_number, head_sha, body, [], event)
+    review_id, _ = _try_submit_review(repo, pr_number, head_sha, body, [], event)
     if review_id is None:
         # Even the summary failed; degrade to a plain PR comment.
         log.error("Summary review also failed; degrading to plain PR comment")

--- a/ai-review-v2/src/github_api.py
+++ b/ai-review-v2/src/github_api.py
@@ -1,0 +1,340 @@
+"""GitHub interactions: PR metadata, file fetching, review posting, state-branch sync.
+
+State branch strategy
+---------------------
+The SQLite knowledge DB lives on a dedicated orphan branch named `__reviewer_state__`
+in the same repo. On startup we shallow-clone just that branch into $STATE_DIR.
+After the run, if the DB changed, we commit it back with `[skip ci]` and push.
+
+This gives us:
+- Zero external infra (no S3, no Postgres)
+- True persistence (not subject to Actions cache eviction)
+- Version-controlled, auditable, trivially backed up
+- Conflict-tolerant (pull-rebase loop on push failure)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+log = logging.getLogger(__name__)
+
+
+# ============================================================
+# DATA MODEL
+# ============================================================
+
+@dataclass
+class ChangedFile:
+    path: str
+    status: str         # added | modified | removed | renamed
+    additions: int
+    deletions: int
+    blob_sha_new: str   # head-side blob sha (for incremental review)
+    diff: str = ""
+    diff_line_numbers: set[int] = field(default_factory=set)
+    language: str = ""
+    old_content: str | None = None
+    new_content: str | None = None
+    analyzer_output: str = ""
+
+
+# ============================================================
+# SHELL HELPERS
+# ============================================================
+
+def gh(args: list[str], **kw) -> str:
+    r = subprocess.run(["gh", *args], capture_output=True, text=True, **kw)
+    if r.returncode != 0:
+        log.warning("gh %s failed: %s", " ".join(args[:3]), r.stderr.strip()[:300])
+        return ""
+    return r.stdout
+
+
+def git(args: list[str], cwd: str | None = None, check: bool = True, **kw) -> subprocess.CompletedProcess:
+    r = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, **kw)
+    if check and r.returncode != 0:
+        log.warning("git %s failed: %s", " ".join(args[:3]), r.stderr.strip()[:300])
+    return r
+
+
+# ============================================================
+# PR METADATA
+# ============================================================
+
+def get_pr_metadata(repo: str, pr_number: int) -> dict:
+    out = gh([
+        "pr", "view", str(pr_number), "--repo", repo,
+        "--json", "title,body,labels,author,baseRefName,headRefName,additions,deletions,commits",
+    ])
+    return json.loads(out) if out else {}
+
+
+# ============================================================
+# CHANGED FILES
+# ============================================================
+
+def get_changed_files(repo: str, pr_number: int) -> list[ChangedFile]:
+    out = gh([
+        "api", "--paginate",
+        f"repos/{repo}/pulls/{pr_number}/files",
+    ])
+    if not out:
+        return []
+    data = _parse_paginated_json(out)
+
+    files: list[ChangedFile] = []
+    for f in data:
+        cf = ChangedFile(
+            path=f["filename"],
+            status=f["status"],
+            additions=f.get("additions", 0),
+            deletions=f.get("deletions", 0),
+            blob_sha_new=f.get("sha", ""),
+            diff=f.get("patch", "") or "",
+        )
+        cf.diff_line_numbers = parse_diff_new_lines(cf.diff)
+        cf.language = detect_language(cf.path)
+        files.append(cf)
+    return files
+
+
+def _parse_paginated_json(out: str) -> list:
+    """gh --paginate may return one big array or concatenated arrays."""
+    try:
+        v = json.loads(out)
+        return v if isinstance(v, list) else [v]
+    except json.JSONDecodeError:
+        # paginated arrays often come back as `][` separated
+        try:
+            return json.loads("[" + out.replace("][", ",")
+                              .replace("]\n[", ",") + "]")
+        except json.JSONDecodeError:
+            log.error("failed to parse paginated gh output")
+            return []
+
+
+_LANG_BY_EXT = {
+    ".py": "python", ".pyi": "python",
+    ".js": "javascript", ".mjs": "javascript", ".cjs": "javascript", ".jsx": "javascript",
+    ".ts": "typescript", ".tsx": "tsx",
+    ".go": "go", ".rs": "rust", ".java": "java", ".kt": "kotlin",
+    ".rb": "ruby", ".php": "php", ".cs": "csharp",
+    ".c": "c", ".h": "c", ".cpp": "cpp", ".cc": "cpp", ".hpp": "cpp",
+    ".swift": "swift", ".scala": "scala", ".sh": "bash", ".bash": "bash",
+    ".sql": "sql", ".md": "markdown", ".yml": "yaml", ".yaml": "yaml",
+    ".json": "json", ".toml": "toml",
+}
+
+
+def detect_language(path: str) -> str:
+    return _LANG_BY_EXT.get(Path(path).suffix.lower(), "")
+
+
+def parse_diff_new_lines(diff: str) -> set[int]:
+    """Lines in the new file that appear in diff hunks.
+    GitHub rejects inline comments outside this set."""
+    lines: set[int] = set()
+    cur = 0
+    for line in diff.splitlines():
+        if line.startswith("@@"):
+            m = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            if m:
+                cur = int(m.group(1))
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            lines.add(cur); cur += 1
+        elif line.startswith("-") and not line.startswith("---"):
+            continue
+        elif line.startswith("\\"):
+            continue
+        else:
+            cur += 1
+    return lines
+
+
+# ============================================================
+# FILE CONTENT
+# ============================================================
+
+def fetch_file_contents(files: list[ChangedFile], base_sha: str, head_sha: str) -> None:
+    for f in files:
+        if f.status not in ("added",):
+            f.old_content = git_show(base_sha, f.path)
+        if f.status not in ("removed",):
+            f.new_content = git_show(head_sha, f.path)
+
+
+def git_show(ref: str, path: str) -> str | None:
+    r = git(["show", f"{ref}:{path}"], check=False)
+    return r.stdout if r.returncode == 0 else None
+
+
+# ============================================================
+# POSTING REVIEW
+# ============================================================
+
+def post_review(
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    body: str,
+    inline_comments: list[dict],
+    event: str,
+) -> int | None:
+    """POST /repos/{owner}/{repo}/pulls/{pr}/reviews. Returns the review id."""
+    payload = {
+        "commit_id": head_sha,
+        "body": body,
+        "event": event,             # APPROVE | REQUEST_CHANGES | COMMENT
+        "comments": inline_comments,
+    }
+    r = subprocess.run(
+        ["gh", "api", "--method", "POST",
+         f"repos/{repo}/pulls/{pr_number}/reviews",
+         "--input", "-"],
+        input=json.dumps(payload),
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        log.error("review submit failed: %s", r.stderr.strip()[:500])
+        # Fallback: at least post the summary as a comment so it's not lost
+        gh(["pr", "comment", str(pr_number), "--repo", repo, "--body", body])
+        return None
+    try:
+        data = json.loads(r.stdout)
+        return data.get("id")
+    except Exception:
+        return None
+
+
+def post_pr_comment(repo: str, pr_number: int, body: str) -> None:
+    gh(["pr", "comment", str(pr_number), "--repo", repo, "--body", body])
+
+
+def reply_to_comment(repo: str, pr_number: int, parent_comment_id: int, body: str) -> None:
+    """Reply to an issue comment (PR comments are issue comments)."""
+    payload = {"body": body, "in_reply_to": parent_comment_id}
+    subprocess.run(
+        ["gh", "api", "--method", "POST",
+         f"repos/{repo}/issues/{pr_number}/comments",
+         "--input", "-"],
+        input=json.dumps(payload), capture_output=True, text=True,
+    )
+
+
+# ============================================================
+# STATE BRANCH SYNC
+# ============================================================
+
+class StateBranch:
+    """Manages the SQLite DB on the __reviewer_state__ orphan branch."""
+
+    INIT_README = (
+        "# Reviewer State\n\n"
+        "This branch holds the SQLite knowledge DB for the AI PR reviewer.\n"
+        "Do not edit by hand. Do not delete unless you want to lose learnings.\n"
+    )
+
+    def __init__(self, repo: str, branch: str, state_dir: str, token: str):
+        self.repo = repo
+        self.branch = branch
+        self.dir = Path(state_dir)
+        self.token = token
+        self.db_path = self.dir / "state.db"
+
+    def remote_url(self) -> str:
+        return f"https://x-access-token:{self.token}@github.com/{self.repo}.git"
+
+    def setup(self) -> None:
+        """Clone or initialize the state branch into self.dir."""
+        if self.dir.exists():
+            shutil.rmtree(self.dir)
+        self.dir.mkdir(parents=True, exist_ok=True)
+
+        r = git(["clone", "--depth", "1", "--branch", self.branch, self.remote_url(), str(self.dir)],
+                check=False)
+        if r.returncode == 0:
+            log.info("Cloned state branch %s into %s", self.branch, self.dir)
+            self._configure_git()
+            return
+
+        # Branch doesn't exist yet — initialize it as an orphan
+        log.info("State branch %s does not exist; initializing", self.branch)
+        git(["clone", "--depth", "1", self.remote_url(), str(self.dir)])
+        self._configure_git()
+        git(["checkout", "--orphan", self.branch], cwd=str(self.dir))
+        git(["rm", "-rf", "."], cwd=str(self.dir), check=False)
+        (self.dir / "README.md").write_text(self.INIT_README)
+        git(["add", "README.md"], cwd=str(self.dir))
+        git(["commit", "-m", "init: reviewer state branch"], cwd=str(self.dir))
+        git(["push", "origin", self.branch], cwd=str(self.dir))
+
+    def _configure_git(self) -> None:
+        git(["config", "user.email", "reviewer-bot@users.noreply.github.com"], cwd=str(self.dir))
+        git(["config", "user.name", "PR Reviewer Bot"], cwd=str(self.dir))
+
+    def commit_and_push(self, message: str = "update: reviewer state") -> bool:
+        """Commit any changes (DB updates) and push. Retries on conflict.
+
+        Returns True if state was actually pushed; False if no changes."""
+        if not self.dir.exists():
+            return False
+        git(["add", "-A"], cwd=str(self.dir))
+        status = git(["status", "--porcelain"], cwd=str(self.dir), check=False).stdout
+        if not status.strip():
+            log.debug("No state changes to commit")
+            return False
+
+        full_msg = f"{message} [skip ci]"
+        git(["commit", "-m", full_msg], cwd=str(self.dir))
+
+        for attempt in range(5):
+            r = git(["push", "origin", self.branch], cwd=str(self.dir), check=False)
+            if r.returncode == 0:
+                log.info("State pushed to %s (attempt %d)", self.branch, attempt + 1)
+                return True
+            log.info("Push conflicted; pulling and retrying (attempt %d)", attempt + 1)
+            git(["pull", "--rebase", "origin", self.branch], cwd=str(self.dir), check=False)
+        log.error("Failed to push state after 5 attempts; state will be lost this run")
+        return False
+
+
+# ============================================================
+# CI SIGNAL (used by orchestrator to enrich summary prompt)
+# ============================================================
+
+def get_failed_workflow_logs(repo: str, head_sha: str, max_lines: int = 200) -> str:
+    """Return tail of logs for any failed workflow runs on this commit. Best-effort."""
+    out = gh([
+        "api", "--paginate",
+        f"repos/{repo}/actions/runs?head_sha={head_sha}&per_page=10",
+    ])
+    if not out:
+        return ""
+    try:
+        data = json.loads(out)
+        runs = data.get("workflow_runs", []) if isinstance(data, dict) else []
+    except Exception:
+        return ""
+    failed = [r for r in runs if r.get("conclusion") == "failure"][:3]
+    if not failed:
+        return ""
+    parts: list[str] = []
+    for run in failed:
+        run_id = run["id"]
+        name = run.get("name", "?")
+        # gh run view returns text logs
+        log_out = gh(["run", "view", str(run_id), "--repo", repo, "--log-failed"])
+        if log_out:
+            tail = "\n".join(log_out.splitlines()[-max_lines:])
+            parts.append(f"### FAILED WORKFLOW: {name}\n{tail}")
+    return "\n\n".join(parts)

--- a/ai-review-v2/src/knowledge.py
+++ b/ai-review-v2/src/knowledge.py
@@ -1,0 +1,314 @@
+"""Knowledge layer: SQLite-backed learnings, review state, and codegraph cache.
+
+Single SQLite file at $STATE_DIR/state.db, with sqlite-vec loaded for vector
+search over learning embeddings. The file is persisted by syncing the parent
+directory to the `__reviewer_state__` orphan branch (see github_api.py).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+import struct
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+import pathspec
+import sqlite_vec
+
+log = logging.getLogger(__name__)
+
+SCHEMA_VERSION = 1
+
+
+# ============================================================
+# CONNECTION
+# ============================================================
+
+@contextmanager
+def connect(db_path: str | Path) -> Iterator[sqlite3.Connection]:
+    """Open the state DB with sqlite-vec loaded. Auto-applies schema if missing."""
+    db_path = Path(db_path)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.enable_load_extension(True)
+        sqlite_vec.load(conn)
+        conn.enable_load_extension(False)
+        _ensure_schema(conn)
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    schema_sql = Path(__file__).parent.parent / "schema.sql"
+    if not schema_sql.exists():
+        raise FileNotFoundError(f"schema.sql not found at {schema_sql}")
+    conn.executescript(schema_sql.read_text())
+
+
+# ============================================================
+# VECTOR HELPERS
+# ============================================================
+
+def _vec_to_blob(vec: list[float]) -> bytes:
+    return struct.pack(f"{len(vec)}f", *vec)
+
+
+# ============================================================
+# LEARNINGS
+# ============================================================
+
+@dataclass
+class Learning:
+    id: int | None
+    description: str
+    scope: str            # 'repo' | 'org' | 'global'
+    file_pattern: str | None
+    repo: str
+    source_pr: int | None
+    source_comment: int | None
+    created_by: str
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "Learning":
+        return cls(
+            id=row["id"],
+            description=row["description"],
+            scope=row["scope"],
+            file_pattern=row["file_pattern"],
+            repo=row["repo"],
+            source_pr=row["source_pr"],
+            source_comment=row["source_comment"],
+            created_by=row["created_by"],
+        )
+
+
+def insert_learning(
+    conn: sqlite3.Connection, learning: Learning, embedding: list[float]
+) -> int:
+    cur = conn.execute(
+        """INSERT INTO learnings
+           (description, scope, file_pattern, repo, source_pr, source_comment, created_by)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        (
+            learning.description,
+            learning.scope,
+            learning.file_pattern,
+            learning.repo,
+            learning.source_pr,
+            learning.source_comment,
+            learning.created_by,
+        ),
+    )
+    learning_id = cur.lastrowid
+    conn.execute(
+        "INSERT INTO learnings_vec(learning_id, embedding) VALUES (?, ?)",
+        (learning_id, _vec_to_blob(embedding)),
+    )
+    log.info("Inserted learning #%d (scope=%s, repo=%s)", learning_id, learning.scope, learning.repo)
+    return learning_id
+
+
+def search_learnings(
+    conn: sqlite3.Connection,
+    query_embedding: list[float],
+    repo: str,
+    *,
+    file_path: str | None = None,
+    limit: int = 10,
+) -> list[Learning]:
+    """Return up to `limit` learnings relevant to this repo and (optionally) file.
+
+    Vector similarity search filtered by scope/repo + post-filtered by file_pattern.
+    Marks retrieved learnings as used (updates last_used_at, increments usage_count).
+    """
+    blob = _vec_to_blob(query_embedding)
+    rows = conn.execute(
+        """
+        SELECT l.*, vec.distance
+        FROM learnings_vec vec
+        JOIN learnings l ON l.id = vec.learning_id
+        WHERE vec.embedding MATCH ?
+          AND l.active = 1
+          AND (l.scope = 'global' OR (l.scope IN ('org', 'repo') AND l.repo = ?))
+        ORDER BY vec.distance ASC
+        LIMIT ?
+        """,
+        (blob, repo, limit * 3),  # over-fetch, post-filter by file_pattern
+    ).fetchall()
+
+    out: list[Learning] = []
+    ids_used: list[int] = []
+    for r in rows:
+        learning = Learning.from_row(r)
+        if learning.file_pattern and file_path:
+            spec = pathspec.PathSpec.from_lines("gitwildmatch", [learning.file_pattern])
+            if not spec.match_file(file_path):
+                continue
+        out.append(learning)
+        ids_used.append(learning.id)
+        if len(out) >= limit:
+            break
+
+    if ids_used:
+        placeholders = ",".join("?" * len(ids_used))
+        conn.execute(
+            f"UPDATE learnings SET last_used_at = datetime('now'), "
+            f"usage_count = usage_count + 1 WHERE id IN ({placeholders})",
+            ids_used,
+        )
+    return out
+
+
+def deactivate_learning(conn: sqlite3.Connection, learning_id: int) -> None:
+    conn.execute("UPDATE learnings SET active = 0 WHERE id = ?", (learning_id,))
+
+
+# ============================================================
+# REVIEW STATE
+# ============================================================
+
+@dataclass
+class ReviewState:
+    last_head_sha: str
+    last_review_id: int | None
+    reviewed_files: dict[str, str]  # path -> blob_sha at last review
+
+
+def get_review_state(conn: sqlite3.Connection, repo: str, pr_number: int) -> ReviewState | None:
+    row = conn.execute(
+        "SELECT * FROM reviewed_prs WHERE repo = ? AND pr_number = ?",
+        (repo, pr_number),
+    ).fetchone()
+    if not row:
+        return None
+
+    files = {
+        r["path"]: r["blob_sha"]
+        for r in conn.execute(
+            "SELECT path, blob_sha FROM reviewed_files WHERE repo = ? AND pr_number = ?",
+            (repo, pr_number),
+        )
+    }
+    return ReviewState(
+        last_head_sha=row["last_head_sha"],
+        last_review_id=row["last_review_id"],
+        reviewed_files=files,
+    )
+
+
+def save_review_state(
+    conn: sqlite3.Connection,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    review_id: int | None,
+    file_blob_shas: dict[str, str],
+    triage_depth: str,
+    findings_count: int,
+) -> None:
+    conn.execute(
+        """INSERT INTO reviewed_prs
+           (repo, pr_number, last_head_sha, last_review_id, triage_depth, findings_count)
+           VALUES (?, ?, ?, ?, ?, ?)
+           ON CONFLICT(repo, pr_number) DO UPDATE SET
+             last_head_sha = excluded.last_head_sha,
+             last_review_id = excluded.last_review_id,
+             reviewed_at = datetime('now'),
+             triage_depth = excluded.triage_depth,
+             findings_count = excluded.findings_count""",
+        (repo, pr_number, head_sha, review_id, triage_depth, findings_count),
+    )
+    # Replace per-file shas wholesale (small, simpler than diffing)
+    conn.execute(
+        "DELETE FROM reviewed_files WHERE repo = ? AND pr_number = ?",
+        (repo, pr_number),
+    )
+    conn.executemany(
+        "INSERT INTO reviewed_files (repo, pr_number, path, blob_sha) VALUES (?, ?, ?, ?)",
+        [(repo, pr_number, p, sha) for p, sha in file_blob_shas.items()],
+    )
+
+
+# ============================================================
+# CODEGRAPH CACHE
+# ============================================================
+
+def get_cached_symbols(
+    conn: sqlite3.Connection, repo: str, path: str, content_sha: str
+) -> list[dict] | None:
+    row = conn.execute(
+        "SELECT symbols FROM file_symbols WHERE repo = ? AND path = ? AND content_sha = ?",
+        (repo, path, content_sha),
+    ).fetchone()
+    return json.loads(row["symbols"]) if row else None
+
+
+def cache_symbols(
+    conn: sqlite3.Connection,
+    repo: str,
+    path: str,
+    content_sha: str,
+    language: str,
+    symbols: list[dict],
+) -> None:
+    conn.execute(
+        """INSERT INTO file_symbols (repo, path, content_sha, language, symbols)
+           VALUES (?, ?, ?, ?, ?)
+           ON CONFLICT(repo, path) DO UPDATE SET
+             content_sha = excluded.content_sha,
+             language = excluded.language,
+             symbols = excluded.symbols,
+             cached_at = datetime('now')""",
+        (repo, path, content_sha, language, json.dumps(symbols)),
+    )
+
+
+def content_sha(content: str | bytes) -> str:
+    if isinstance(content, str):
+        content = content.encode("utf-8", errors="replace")
+    return hashlib.sha1(content).hexdigest()
+
+
+# ============================================================
+# COST TELEMETRY
+# ============================================================
+
+def log_llm_call(
+    conn: sqlite3.Connection,
+    repo: str,
+    pr_number: int | None,
+    stage: str,
+    usage: dict,
+    succeeded: bool,
+    error: str | None = None,
+) -> None:
+    conn.execute(
+        """INSERT INTO llm_calls
+           (repo, pr_number, stage, model, prompt_tokens, completion_tokens,
+            duration_ms, succeeded, error)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            repo,
+            pr_number,
+            stage,
+            usage.get("model", "?"),
+            usage.get("prompt_tokens"),
+            usage.get("completion_tokens"),
+            usage.get("duration_ms"),
+            1 if succeeded else 0,
+            error,
+        ),
+    )

--- a/ai-review-v2/src/knowledge.py
+++ b/ai-review-v2/src/knowledge.py
@@ -35,7 +35,11 @@ def connect(db_path: str | Path) -> Iterator[sqlite3.Connection]:
     db_path = Path(db_path)
     db_path.parent.mkdir(parents=True, exist_ok=True)
 
-    conn = sqlite3.connect(str(db_path))
+    # check_same_thread=False: per-file review pass uses a ThreadPoolExecutor
+    # and each worker calls knowledge.log_llm_call on this same connection.
+    # SQLite itself serializes writes; we just need to opt out of Python's
+    # client-side thread check.
+    conn = sqlite3.connect(str(db_path), check_same_thread=False)
     conn.row_factory = sqlite3.Row
     try:
         conn.enable_load_extension(True)

--- a/ai-review-v2/src/knowledge.py
+++ b/ai-review-v2/src/knowledge.py
@@ -139,18 +139,23 @@ def search_learnings(
     Marks retrieved learnings as used (updates last_used_at, increments usage_count).
     """
     blob = _vec_to_blob(query_embedding)
+    k = limit * 3  # over-fetch; post-filter by file_pattern below
+    # sqlite-vec's KNN syntax requires an explicit `k = ?` constraint on
+    # the vec table (a plain LIMIT clause is not enough when the vec table
+    # is joined). The application-level filters and ORDER BY apply after
+    # the KNN candidate set is built.
     rows = conn.execute(
         """
         SELECT l.*, vec.distance
         FROM learnings_vec vec
         JOIN learnings l ON l.id = vec.learning_id
         WHERE vec.embedding MATCH ?
+          AND k = ?
           AND l.active = 1
           AND (l.scope = 'global' OR (l.scope IN ('org', 'repo') AND l.repo = ?))
         ORDER BY vec.distance ASC
-        LIMIT ?
         """,
-        (blob, repo, limit * 3),  # over-fetch, post-filter by file_pattern
+        (blob, k, repo),
     ).fetchall()
 
     out: list[Learning] = []

--- a/ai-review-v2/src/learn.py
+++ b/ai-review-v2/src/learn.py
@@ -22,6 +22,12 @@ log = logging.getLogger(__name__)
 # Words used to dismiss / forget a learning by id, e.g. "@reviewer forget #42"
 _FORGET_RE = re.compile(r"\b(forget|delete|remove)\s+#?(\d+)\b", re.IGNORECASE)
 
+# Every comment v2 posts (reviews, inline findings, learn-mode replies) carries
+# this HTML marker. Detecting it is the source-of-truth way to skip our own
+# messages — username comparison is unreliable because the bot routinely posts
+# under a real user's PAT (their token, not github-actions[bot]).
+V2_MARKER = "<!-- pr-reviewer-v2 -->"
+
 
 def process_comment_event(cfg: Config, conn, event: dict) -> None:
     """Entry point. `event` is the GitHub issue_comment webhook payload."""
@@ -31,10 +37,20 @@ def process_comment_event(cfg: Config, conn, event: dict) -> None:
     comment = event.get("comment", {})
     body = comment.get("body", "") or ""
     user = comment.get("user", {}).get("login", "")
-    if not _mentions_bot(body, cfg.bot_username) and "@reviewer" not in body:
+
+    # ① Skip anything we posted ourselves. The marker check covers the PAT case
+    # the username check misses, and prevents the "bot replies to bot" loop
+    # (our reply contains "@reviewer forget #N", which would otherwise re-fire
+    # this workflow).
+    if V2_MARKER in body:
+        log.info("Skipping comment carrying v2 marker (self-bot output)")
         return
-    if user == cfg.bot_username or user.endswith("[bot]"):
-        return  # don't process our own messages
+    if user.endswith("[bot]"):
+        return
+
+    # ② Mention check is case-insensitive so @Reviewer / @REVIEWER both work.
+    if not _is_mention(body, cfg.bot_username):
+        return
 
     pr_number = event.get("issue", {}).get("number") or cfg.pr_number
     if not pr_number:
@@ -49,7 +65,7 @@ def process_comment_event(cfg: Config, conn, event: dict) -> None:
         log.info("Deactivated learning #%d (requested by %s)", learning_id, user)
         github_api.reply_to_comment(
             cfg.github_repo, pr_number, comment["id"],
-            f"🧠 Forgot learning #{learning_id}.",
+            f"{V2_MARKER}\n🧠 Forgot learning #{learning_id}.",
         )
         return
 
@@ -84,7 +100,8 @@ def process_comment_event(cfg: Config, conn, event: dict) -> None:
         log.info("Not a learning: %s", result.get("reasoning", ""))
         github_api.reply_to_comment(
             cfg.github_repo, pr_number, comment["id"],
-            f"👍 Noted. _(Not stored as a durable learning: {result.get('reasoning', '')})_",
+            f"{V2_MARKER}\n👍 Noted. _(Not stored as a durable learning: "
+            f"{result.get('reasoning', '')})_",
         )
         return
 
@@ -117,7 +134,7 @@ def process_comment_event(cfg: Config, conn, event: dict) -> None:
     pattern_str = f" (scoped to `{learning.file_pattern}`)" if learning.file_pattern else ""
     github_api.reply_to_comment(
         cfg.github_repo, pr_number, comment["id"],
-        f"🧠 **Learning #{learning_id} added{pattern_str}**\n\n"
+        f"{V2_MARKER}\n🧠 **Learning #{learning_id} added{pattern_str}**\n\n"
         f"> {description}\n\n"
         f"_Scope: `{scope_str}`. Reply `@reviewer forget #{learning_id}` to remove._",
     )
@@ -127,12 +144,24 @@ def process_comment_event(cfg: Config, conn, event: dict) -> None:
 # HELPERS
 # ============================================================
 
-def _mentions_bot(body: str, bot_username: str) -> bool:
-    if not bot_username:
-        return False
-    # Match @bot-name, with or without [bot]
-    base = bot_username.replace("[bot]", "")
-    return f"@{base}" in body or f"@{bot_username}" in body
+def _is_mention(body: str, bot_username: str) -> bool:
+    """Case-insensitive @-mention check.
+
+    Always matches `@reviewer` (the generic alias we tell users to use in
+    docs). Also matches the configured bot_username if set, with or without
+    a `[bot]` suffix. All comparisons are lowercased — `@Reviewer`,
+    `@REVIEWER`, and `@reviewer` all trigger the loop.
+    """
+    bl = body.lower()
+    if "@reviewer" in bl:
+        return True
+    if bot_username:
+        base = bot_username.replace("[bot]", "").lower()
+        if base and f"@{base}" in bl:
+            return True
+        if f"@{bot_username.lower()}" in bl:
+            return True
+    return False
 
 
 def _find_parent_review_comment(cfg: Config, comment: dict, event: dict) -> dict | None:

--- a/ai-review-v2/src/learn.py
+++ b/ai-review-v2/src/learn.py
@@ -1,0 +1,183 @@
+"""Listener for `@reviewer` mentions on PR comments.
+
+Triggered by the `issue_comment` GitHub event. When a user replies to a review
+comment with `@<bot> ...`, we ask the LLM whether the reply expresses a durable
+team preference. If yes, we embed it, store it in SQLite, and reply with
+"Learning added."
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import subprocess
+
+from . import github_api, knowledge, llm, prompts
+from .config import Config
+
+log = logging.getLogger(__name__)
+
+# Words used to dismiss / forget a learning by id, e.g. "@reviewer forget #42"
+_FORGET_RE = re.compile(r"\b(forget|delete|remove)\s+#?(\d+)\b", re.IGNORECASE)
+
+
+def process_comment_event(cfg: Config, conn, event: dict) -> None:
+    """Entry point. `event` is the GitHub issue_comment webhook payload."""
+    if event.get("action") not in ("created", "edited"):
+        return
+
+    comment = event.get("comment", {})
+    body = comment.get("body", "") or ""
+    user = comment.get("user", {}).get("login", "")
+    if not _mentions_bot(body, cfg.bot_username) and "@reviewer" not in body:
+        return
+    if user == cfg.bot_username or user.endswith("[bot]"):
+        return  # don't process our own messages
+
+    pr_number = event.get("issue", {}).get("number") or cfg.pr_number
+    if not pr_number:
+        log.warning("No PR number found in event; skipping")
+        return
+
+    # Handle "forget" commands first — they don't need LLM
+    m = _FORGET_RE.search(body)
+    if m:
+        learning_id = int(m.group(2))
+        knowledge.deactivate_learning(conn, learning_id)
+        log.info("Deactivated learning #%d (requested by %s)", learning_id, user)
+        github_api.reply_to_comment(
+            cfg.github_repo, pr_number, comment["id"],
+            f"🧠 Forgot learning #{learning_id}.",
+        )
+        return
+
+    # Find the parent review comment (the line the user is replying to)
+    parent = _find_parent_review_comment(cfg, comment, event)
+    parent_body = parent.get("body", "") if parent else "(general PR comment)"
+    file_path = parent.get("path") if parent else None
+
+    pr_meta = github_api.get_pr_metadata(cfg.github_repo, pr_number)
+
+    extract_client = llm.make_client(cfg.review)
+    try:
+        result, usage = llm.chat(
+            extract_client, cfg.review.model,
+            prompts.LEARNING_EXTRACT_SYSTEM,
+            prompts.learning_extract_user(
+                pr_title=pr_meta.get("title", ""),
+                file_path=file_path,
+                parent_review_comment=parent_body,
+                user_reply=body,
+                repo=cfg.github_repo,
+            ),
+        )
+        knowledge.log_llm_call(conn, cfg.github_repo, pr_number, "learning_extract", usage, True)
+    except Exception as e:
+        log.exception("learning extraction failed")
+        knowledge.log_llm_call(conn, cfg.github_repo, pr_number, "learning_extract",
+                               {"model": cfg.review.model}, False, str(e))
+        return
+
+    if not result.get("is_learning"):
+        log.info("Not a learning: %s", result.get("reasoning", ""))
+        github_api.reply_to_comment(
+            cfg.github_repo, pr_number, comment["id"],
+            f"👍 Noted. _(Not stored as a durable learning: {result.get('reasoning', '')})_",
+        )
+        return
+
+    description = result.get("description", "").strip()
+    if not description:
+        return
+
+    # Embed and store
+    try:
+        embed_client = llm.make_client(cfg.embedding)
+        vectors = llm.embed(embed_client, cfg.embedding.model, [description])
+        if not vectors:
+            return
+        learning = knowledge.Learning(
+            id=None,
+            description=description,
+            scope=result.get("scope") or "repo",
+            file_pattern=result.get("file_pattern"),
+            repo=cfg.github_repo,
+            source_pr=pr_number,
+            source_comment=comment["id"],
+            created_by=user,
+        )
+        learning_id = knowledge.insert_learning(conn, learning, vectors[0])
+    except Exception:
+        log.exception("failed to store learning")
+        return
+
+    scope_str = learning.scope
+    pattern_str = f" (scoped to `{learning.file_pattern}`)" if learning.file_pattern else ""
+    github_api.reply_to_comment(
+        cfg.github_repo, pr_number, comment["id"],
+        f"🧠 **Learning #{learning_id} added{pattern_str}**\n\n"
+        f"> {description}\n\n"
+        f"_Scope: `{scope_str}`. Reply `@reviewer forget #{learning_id}` to remove._",
+    )
+
+
+# ============================================================
+# HELPERS
+# ============================================================
+
+def _mentions_bot(body: str, bot_username: str) -> bool:
+    if not bot_username:
+        return False
+    # Match @bot-name, with or without [bot]
+    base = bot_username.replace("[bot]", "")
+    return f"@{base}" in body or f"@{bot_username}" in body
+
+
+def _find_parent_review_comment(cfg: Config, comment: dict, event: dict) -> dict | None:
+    """If this comment is a reply to a pull-request review comment, fetch the parent.
+
+    GitHub's `issue_comment` event doesn't include the parent for review-thread
+    replies — we have to look it up from the comment's in_reply_to or fall back
+    to the most recent review comment on the same path/line.
+    """
+    in_reply_to = comment.get("in_reply_to_id")
+    if not in_reply_to:
+        return None
+
+    pr_number = event.get("issue", {}).get("number") or cfg.pr_number
+    try:
+        out = subprocess.run(
+            ["gh", "api", f"repos/{cfg.github_repo}/pulls/comments/{in_reply_to}"],
+            capture_output=True, text=True, timeout=20,
+        )
+        if out.returncode == 0:
+            return json.loads(out.stdout)
+    except Exception:
+        log.exception("failed to fetch parent comment %s", in_reply_to)
+    return None
+
+
+# ============================================================
+# CLI ENTRY (called by learn workflow)
+# ============================================================
+
+def main() -> int:
+    from . import config
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    cfg = config.load()
+
+    event_path = os.environ.get("GITHUB_EVENT_PATH", "")
+    if not event_path or not os.path.exists(event_path):
+        log.error("GITHUB_EVENT_PATH not set or missing")
+        return 1
+    with open(event_path) as f:
+        event = json.load(f)
+
+    branch = github_api.StateBranch(cfg.github_repo, cfg.state_branch, cfg.state_dir, cfg.github_token)
+    branch.setup()
+    with knowledge.connect(branch.db_path) as conn:
+        process_comment_event(cfg, conn, event)
+    branch.commit_and_push("update: learning")
+    return 0

--- a/ai-review-v2/src/llm.py
+++ b/ai-review-v2/src/llm.py
@@ -1,0 +1,178 @@
+"""LLM client wrapper.
+
+Handles both chat completions and embeddings against any OpenAI-compatible
+endpoint. Resilient to provider quirks (response_format support varies, JSON
+sometimes wrapped in code fences, transient errors).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from typing import Any
+
+from openai import APIError, APITimeoutError, OpenAI, RateLimitError
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from .config import LLMEndpoint
+
+log = logging.getLogger(__name__)
+
+
+# ============================================================
+# CLIENT
+# ============================================================
+
+def make_client(endpoint: LLMEndpoint) -> OpenAI:
+    return OpenAI(
+        base_url=endpoint.base_url,
+        api_key=endpoint.api_key,
+        timeout=180.0,
+        max_retries=0,  # we do our own retries with tenacity for finer control
+    )
+
+
+# ============================================================
+# CHAT COMPLETIONS
+# ============================================================
+
+@retry(
+    retry=retry_if_exception_type((APITimeoutError, RateLimitError, APIError)),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=2, min=4, max=60),
+    reraise=True,
+)
+def chat(
+    client: OpenAI,
+    model: str,
+    system: str,
+    user: str,
+    *,
+    json_mode: bool = True,
+    temperature: float = 0.2,
+) -> tuple[Any, dict]:
+    """Run a chat completion. Returns (parsed_result, usage_dict).
+
+    When json_mode is True, parses the response as JSON, retrying without
+    response_format if the provider rejects it.
+    """
+    started = time.monotonic()
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": user},
+    ]
+    kwargs: dict = {"model": model, "messages": messages, "temperature": temperature}
+
+    try:
+        if json_mode:
+            try:
+                resp = client.chat.completions.create(
+                    **kwargs, response_format={"type": "json_object"}
+                )
+            except (APIError, TypeError):
+                # Provider doesn't support response_format — fall back
+                resp = client.chat.completions.create(**kwargs)
+        else:
+            resp = client.chat.completions.create(**kwargs)
+    except Exception:
+        log.exception("LLM chat call failed")
+        raise
+
+    content = (resp.choices[0].message.content or "").strip()
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+
+    usage = {
+        "model": model,
+        "prompt_tokens": getattr(resp.usage, "prompt_tokens", None) if resp.usage else None,
+        "completion_tokens": getattr(resp.usage, "completion_tokens", None) if resp.usage else None,
+        "duration_ms": elapsed_ms,
+    }
+
+    result: Any = content
+    if json_mode:
+        result = parse_json(content)
+
+    return result, usage
+
+
+# ============================================================
+# EMBEDDINGS
+# ============================================================
+
+@retry(
+    retry=retry_if_exception_type((APITimeoutError, RateLimitError, APIError)),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=2, min=4, max=30),
+    reraise=True,
+)
+def embed(client: OpenAI, model: str, texts: list[str]) -> list[list[float]]:
+    """Embed a batch of texts. Returns a list of vectors aligned with inputs."""
+    if not texts:
+        return []
+    # Strip leading/trailing whitespace; some providers error on empty strings.
+    cleaned = [t.strip() or " " for t in texts]
+    resp = client.embeddings.create(model=model, input=cleaned)
+    return [d.embedding for d in resp.data]
+
+
+# ============================================================
+# ROBUST JSON PARSING
+# ============================================================
+
+_JSON_FENCE_RE = re.compile(r"^```(?:json)?\s*(.*?)\s*```$", re.DOTALL)
+
+
+def parse_json(s: str) -> dict:
+    """Best-effort JSON extraction from possibly-noisy LLM output."""
+    s = s.strip()
+    if not s:
+        return {}
+
+    # Code-fenced response
+    m = _JSON_FENCE_RE.match(s)
+    if m:
+        s = m.group(1).strip()
+
+    # Direct parse
+    try:
+        v = json.loads(s)
+        return v if isinstance(v, dict) else {"_raw": v}
+    except json.JSONDecodeError:
+        pass
+
+    # Greedy: find first balanced {...} block
+    start = s.find("{")
+    if start == -1:
+        log.warning("No JSON object found in LLM response")
+        return {}
+
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(start, len(s)):
+        ch = s[i]
+        if escape:
+            escape = False
+            continue
+        if ch == "\\":
+            escape = True
+            continue
+        if ch == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    v = json.loads(s[start:i + 1])
+                    return v if isinstance(v, dict) else {"_raw": v}
+                except json.JSONDecodeError:
+                    log.warning("Found unbalanced-looking JSON; giving up")
+                    return {}
+    return {}

--- a/ai-review-v2/src/orchestrator.py
+++ b/ai-review-v2/src/orchestrator.py
@@ -1,0 +1,397 @@
+"""Review orchestrator: the 5-pass pipeline.
+
+  1. Triage      → depth + focus areas        (cheap model)
+  2. Analyzers   → ruff/eslint/semgrep/etc    (no LLM)
+  3. Codegraph   → cross-file callers         (tree-sitter + ripgrep)
+  4. Summary     → TL;DR + walkthrough        (smart model, 1 call)
+  5. Per-file    → deep review per file        (smart model, N parallel calls)
+                   — pulls path instructions and relevant learnings into prompt
+  6. Cross-cut   → PR-level issues + verdict   (smart model, 1 call)
+  7. Post        → single GitHub Review
+
+Side effects: writes telemetry to SQLite, updates review state for incremental
+re-review on subsequent pushes.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import logging
+import sqlite3
+from pathlib import Path
+
+import pathspec
+
+from . import analyzers, codegraph, github_api, knowledge, llm, prompts
+from .config import Config
+from .github_api import ChangedFile
+
+log = logging.getLogger(__name__)
+
+
+SEVERITY_EMOJI = {"critical": "🔴", "major": "🟠", "minor": "🟡", "nit": "💭"}
+
+
+def review_pr(cfg: Config, conn: sqlite3.Connection) -> None:
+    log.info("Reviewing PR #%d in %s", cfg.pr_number, cfg.github_repo)
+
+    # --- Idempotency check ---
+    prior = knowledge.get_review_state(conn, cfg.github_repo, cfg.pr_number)
+    if prior and prior.last_head_sha == cfg.head_sha:
+        log.info("Already reviewed %s at this head SHA; skipping", cfg.head_sha)
+        return
+
+    # --- Context gathering ---
+    pr = github_api.get_pr_metadata(cfg.github_repo, cfg.pr_number)
+    all_files = github_api.get_changed_files(cfg.github_repo, cfg.pr_number)
+    files = [f for f in all_files if not _should_skip(f.path, cfg.skip_patterns)][:cfg.max_files]
+    log.info("%d files in scope (%d filtered)", len(files), len(all_files) - len(files))
+    if not files:
+        github_api.post_pr_comment(cfg.github_repo, cfg.pr_number, "_No reviewable files in this PR._")
+        return
+
+    github_api.fetch_file_contents(files, cfg.base_sha, cfg.head_sha)
+    conventions = _load_repo_conventions()
+
+    # --- Incremental: filter to files whose content actually changed since last review ---
+    files_for_deep_review = files
+    if cfg.enable_incremental and prior:
+        files_for_deep_review = [
+            f for f in files
+            if prior.reviewed_files.get(f.path) != f.blob_sha_new
+        ]
+        if not files_for_deep_review:
+            log.info("All files unchanged since last review; updating state only")
+            _update_state(conn, cfg, files, prior.last_review_id, "skip", 0)
+            return
+        log.info("Incremental: %d/%d files changed since last review",
+                 len(files_for_deep_review), len(files))
+
+    # === Pass 1: Triage ===
+    triage_client = llm.make_client(cfg.triage)
+    log.info("[triage] model=%s", cfg.triage.model)
+    try:
+        triage, usage = llm.chat(
+            triage_client, cfg.triage.model,
+            prompts.TRIAGE_SYSTEM, prompts.triage_user(pr, files),
+        )
+        knowledge.log_llm_call(conn, cfg.github_repo, cfg.pr_number, "triage", usage, True)
+    except Exception as e:
+        log.exception("triage failed; defaulting to 'standard'")
+        knowledge.log_llm_call(conn, cfg.github_repo, cfg.pr_number, "triage",
+                               {"model": cfg.triage.model}, False, str(e))
+        triage = {"depth": "standard", "focus_areas": [], "reasoning": "triage error"}
+
+    depth = triage.get("depth", "standard")
+    focus_areas = triage.get("focus_areas") or []
+    log.info("triage → depth=%s focus=%s", depth, focus_areas)
+
+    if depth == "skip":
+        github_api.post_pr_comment(
+            cfg.github_repo, cfg.pr_number,
+            f"🤖 **Skipping review** — {triage.get('reasoning', '')}",
+        )
+        _update_state(conn, cfg, files, prior.last_review_id if prior else None, "skip", 0)
+        return
+
+    # === Pass 2: Static analyzers ===
+    if cfg.enable_analyzers and depth in ("standard", "deep"):
+        log.info("[analyzers]")
+        analyzers.run_all(files)
+
+    # === Pass 3: Codegraph ===
+    codegraph_blocks: dict[str, str] = {}
+    if cfg.enable_codegraph and depth in ("standard", "deep"):
+        log.info("[codegraph]")
+        for f in files_for_deep_review:
+            if not f.new_content or not f.language:
+                continue
+            try:
+                ctx = codegraph.build_context_for_file(
+                    conn,
+                    repo=cfg.github_repo,
+                    path=f.path,
+                    content=f.new_content,
+                    language=f.language,
+                    diff_line_numbers=f.diff_line_numbers,
+                    repo_root=".",
+                )
+                block = ctx.render()
+                if block:
+                    codegraph_blocks[f.path] = block
+            except Exception:
+                log.exception("codegraph failed for %s", f.path)
+        log.info("codegraph: callers found for %d/%d files",
+                 len(codegraph_blocks), len(files_for_deep_review))
+
+    # === Learnings retrieval (per file, via embedding) ===
+    learnings_by_file: dict[str, list] = {}
+    if cfg.enable_learnings:
+        embed_client = llm.make_client(cfg.embedding)
+        # Query = file path + first 2KB of new content. Cheap to embed; good signal.
+        try:
+            queries = []
+            for f in files_for_deep_review:
+                q = f.path + "\n\n" + (f.new_content or "")[:2000]
+                queries.append(q)
+            if queries:
+                vectors = llm.embed(embed_client, cfg.embedding.model, queries)
+                for f, vec in zip(files_for_deep_review, vectors, strict=False):
+                    learnings_by_file[f.path] = knowledge.search_learnings(
+                        conn, vec, repo=cfg.github_repo, file_path=f.path, limit=6
+                    )
+                total = sum(len(v) for v in learnings_by_file.values())
+                log.info("learnings retrieved: %d total across files", total)
+        except Exception:
+            log.exception("learnings retrieval failed; continuing without")
+
+    # === Pass 4: Summary ===
+    review_client = llm.make_client(cfg.review)
+    ci_logs = github_api.get_failed_workflow_logs(cfg.github_repo, cfg.head_sha) if depth in ("standard", "deep") else ""
+
+    log.info("[summary] model=%s", cfg.review.model)
+    try:
+        summary, usage = llm.chat(
+            review_client, cfg.review.model,
+            prompts.SUMMARY_SYSTEM,
+            prompts.summary_user(pr, files, conventions, ci_logs),
+        )
+        knowledge.log_llm_call(conn, cfg.github_repo, cfg.pr_number, "summary", usage, True)
+    except Exception as e:
+        log.exception("summary failed")
+        knowledge.log_llm_call(conn, cfg.github_repo, cfg.pr_number, "summary",
+                               {"model": cfg.review.model}, False, str(e))
+        summary = {"tldr": "(summary generation failed)", "walkthrough": "",
+                   "sequence_diagram": None, "risk_areas": [],
+                   "suggested_reviewers_focus": ""}
+
+    # === Pass 5: Per-file review (parallel) ===
+    reviewable = [
+        f for f in files_for_deep_review
+        if f.new_content
+        and len(f.new_content) <= cfg.max_file_bytes
+        and not _is_generated(f.new_content)
+        and f.status != "removed"
+    ]
+    log.info("[per-file] %d files, parallel=%d", len(reviewable), cfg.parallel_file_reviews)
+
+    def review_one(f: ChangedFile) -> tuple[str, dict]:
+        try:
+            path_instr = _match_path_instructions(f.path, cfg)
+            user = prompts.file_review_user(
+                f, pr, conventions, focus_areas,
+                codegraph_block=codegraph_blocks.get(f.path, ""),
+                learnings=learnings_by_file.get(f.path),
+                path_instructions=path_instr,
+            )
+            result, usage = llm.chat(
+                review_client, cfg.review.model,
+                prompts.FILE_REVIEW_SYSTEM, user,
+            )
+            knowledge.log_llm_call(conn, cfg.github_repo, cfg.pr_number, "file_review", usage, True)
+            return f.path, result
+        except Exception as e:
+            log.exception("file review failed: %s", f.path)
+            knowledge.log_llm_call(conn, cfg.github_repo, cfg.pr_number, "file_review",
+                                   {"model": cfg.review.model}, False, str(e))
+            return f.path, {"file_summary": "", "findings": []}
+
+    file_findings: dict[str, dict] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=cfg.parallel_file_reviews) as ex:
+        for path, result in ex.map(review_one, reviewable):
+            file_findings[path] = result
+            n = len(result.get("findings", []))
+            if n:
+                log.info("  %s: %d findings", path, n)
+
+    # === Pass 6: Cross-cutting ===
+    log.info("[cross-cut]")
+    try:
+        cross, usage = llm.chat(
+            review_client, cfg.review.model,
+            prompts.CROSS_CUT_SYSTEM,
+            prompts.cross_cut_user(pr, summary, file_findings, files),
+        )
+        knowledge.log_llm_call(conn, cfg.github_repo, cfg.pr_number, "cross_cut", usage, True)
+    except Exception as e:
+        log.exception("cross-cut failed")
+        knowledge.log_llm_call(conn, cfg.github_repo, cfg.pr_number, "cross_cut",
+                               {"model": cfg.review.model}, False, str(e))
+        cross = {"cross_cutting_findings": [], "verdict": "comment",
+                 "verdict_reasoning": "cross-cut error"}
+
+    # === Filter by confidence ===
+    for fr in file_findings.values():
+        fr["findings"] = [
+            x for x in fr.get("findings", [])
+            if int(x.get("confidence", 0) or 0) >= cfg.confidence_threshold
+        ]
+    cross["cross_cutting_findings"] = [
+        x for x in cross.get("cross_cutting_findings", [])
+        if int(x.get("confidence", 0) or 0) >= cfg.confidence_threshold
+    ]
+
+    # === Pass 7: Post ===
+    review_id = _post_review(cfg, pr, summary, file_findings, cross, files)
+    total_findings = sum(len(fr.get("findings", [])) for fr in file_findings.values())
+    _update_state(conn, cfg, files, review_id, depth, total_findings)
+    log.info("done. %d findings posted. review_id=%s", total_findings, review_id)
+
+
+# ============================================================
+# HELPERS
+# ============================================================
+
+def _should_skip(path: str, patterns: list[str]) -> bool:
+    spec = pathspec.PathSpec.from_lines("gitwildmatch", patterns)
+    return spec.match_file(path)
+
+
+def _is_generated(content: str) -> bool:
+    head = content[:500].lower()
+    return any(m in head for m in (
+        "@generated", "do not edit", "auto-generated", "code generated by",
+    ))
+
+
+def _load_repo_conventions() -> str:
+    for name in ("CLAUDE.md", "AGENTS.md", ".cursorrules", ".windsurfrules",
+                 "CODESTYLE.md", "STYLEGUIDE.md", "CONTRIBUTING.md"):
+        p = Path(name)
+        if p.exists() and p.is_file():
+            try:
+                return p.read_text()[:8000]
+            except Exception:
+                continue
+    return ""
+
+
+def _match_path_instructions(path: str, cfg: Config) -> str:
+    out = []
+    for pi in cfg.path_instructions:
+        spec = pathspec.PathSpec.from_lines("gitwildmatch", [pi.pattern])
+        if spec.match_file(path):
+            out.append(pi.instructions.strip())
+    return "\n\n".join(out)
+
+
+def _update_state(
+    conn: sqlite3.Connection,
+    cfg: Config,
+    files: list[ChangedFile],
+    review_id: int | None,
+    depth: str,
+    findings_count: int,
+) -> None:
+    blob_shas = {f.path: f.blob_sha_new for f in files if f.blob_sha_new}
+    knowledge.save_review_state(
+        conn, cfg.github_repo, cfg.pr_number,
+        cfg.head_sha, review_id, blob_shas, depth, findings_count,
+    )
+
+
+# ============================================================
+# POSTING
+# ============================================================
+
+def _post_review(
+    cfg: Config,
+    pr: dict,
+    summary: dict,
+    file_findings: dict,
+    cross: dict,
+    files: list[ChangedFile],
+) -> int | None:
+    diff_lines = {f.path: f.diff_line_numbers for f in files}
+
+    inline: list[dict] = []
+    dropped: list[tuple[str, dict]] = []
+
+    for path, fr in file_findings.items():
+        for x in fr.get("findings", []):
+            line = x.get("line")
+            if not isinstance(line, int):
+                continue
+            if line in diff_lines.get(path, set()):
+                inline.append({"path": path, "line": line, "side": "RIGHT",
+                               "body": _format_finding(x)})
+            else:
+                dropped.append((path, x))
+
+    for x in cross.get("cross_cutting_findings", []):
+        path, line = x.get("file"), x.get("line")
+        if path and isinstance(line, int) and line in diff_lines.get(path, set()):
+            inline.append({"path": path, "line": line, "side": "RIGHT",
+                           "body": _format_finding(x, prefix="🔀 Cross-cutting: ")})
+
+    summary_md = _build_summary_md(summary, file_findings, cross, dropped)
+    event = {
+        "approve": "APPROVE",
+        "comment": "COMMENT",
+        "request_changes": "REQUEST_CHANGES",
+    }.get(cross.get("verdict", "comment"), "COMMENT")
+
+    return github_api.post_review(
+        cfg.github_repo, cfg.pr_number, cfg.head_sha,
+        body=summary_md, inline_comments=inline, event=event,
+    )
+
+
+def _format_finding(f: dict, prefix: str = "") -> str:
+    emoji = SEVERITY_EMOJI.get(f.get("severity", ""), "")
+    header = (f"{emoji} **{prefix}{(f.get('severity') or '').upper()} · "
+              f"{f.get('category', '')}** · confidence {f.get('confidence', '?')}/5")
+    parts = [header, f"### {f.get('title', '')}", f.get("body", "")]
+    sug = f.get("suggestion")
+    if sug and isinstance(sug, str) and sug.strip():
+        sug = sug.strip()
+        if not sug.startswith("```"):
+            parts.append(f"```suggestion\n{sug}\n```")
+        else:
+            parts.append(sug)
+    return "\n\n".join(p for p in parts if p)
+
+
+def _build_summary_md(summary: dict, file_findings: dict, cross: dict,
+                      dropped: list[tuple[str, dict]]) -> str:
+    total = sum(len(fr.get("findings", [])) for fr in file_findings.values())
+    cross_list = cross.get("cross_cutting_findings", [])
+
+    out = ["## 🤖 Automated Review", ""]
+    if summary.get("tldr"):
+        out += [f"**{summary['tldr']}**", ""]
+    if summary.get("walkthrough"):
+        out += ["### Walkthrough", summary["walkthrough"], ""]
+    if summary.get("sequence_diagram"):
+        out += ["### Flow", "```mermaid", summary["sequence_diagram"], "```", ""]
+    if summary.get("suggested_reviewers_focus"):
+        out += ["### Reviewer focus", summary["suggested_reviewers_focus"], ""]
+
+    out.append(f"### Findings  ·  {total} inline  ·  {len(cross_list)} cross-cutting")
+    verdict = cross.get("verdict", "comment")
+    verdict_emoji = {"approve": "✅", "comment": "💬", "request_changes": "🛑"}.get(verdict, "")
+    out += [f"{verdict_emoji} **Verdict: `{verdict}`** — {cross.get('verdict_reasoning', '')}", ""]
+
+    if cross_list:
+        out.append("**Cross-cutting findings:**")
+        for f in cross_list:
+            emoji = SEVERITY_EMOJI.get(f.get("severity", ""), "")
+            loc = f"`{f['file']}`" if f.get("file") else "_PR-level_"
+            out.append(f"- {emoji} {loc} — **{f.get('title', '')}** _(conf {f.get('confidence', '?')}/5)_")
+            body = (f.get("body") or "").replace("\n", " ")[:400]
+            if body:
+                out.append(f"  > {body}")
+        out.append("")
+
+    if dropped:
+        out.append("### Findings outside diff context")
+        for path, x in dropped[:20]:
+            emoji = SEVERITY_EMOJI.get(x.get("severity", ""), "")
+            out.append(f"- {emoji} `{path}` L{x.get('line')} — **{x.get('title', '')}**")
+        out.append("")
+
+    out.append(
+        "<sub>Reply with `@reviewer ...` on any inline comment to teach the bot a "
+        "team preference. Findings below confidence 3 are filtered.</sub>"
+    )
+    return "\n".join(out)

--- a/ai-review-v2/src/orchestrator.py
+++ b/ai-review-v2/src/orchestrator.py
@@ -405,6 +405,28 @@ def _format_finding(f: dict, prefix: str = "") -> str:
     return "\n\n".join(parts)
 
 
+def _strip_code_fence(text: str) -> str:
+    """Strip an outer ```lang ... ``` fence if the LLM included one.
+
+    Models sometimes return `sequence_diagram` already wrapped in a
+    ```mermaid fence. Our caller then wraps it AGAIN, producing
+    nested fences that GitHub renders as plain text instead of a
+    rendered mermaid diagram. Normalize to plain inner content.
+    """
+    s = text.strip()
+    if not s.startswith("```"):
+        return s
+    # Drop the opening fence line (e.g. ```mermaid or ```)
+    first_newline = s.find("\n")
+    if first_newline == -1:
+        return s  # malformed; leave it
+    s = s[first_newline + 1 :]
+    # Drop a trailing fence if present
+    if s.rstrip().endswith("```"):
+        s = s.rstrip()[: -len("```")]
+    return s.rstrip()
+
+
 def _build_summary_md(summary: dict, file_findings: dict, cross: dict,
                       dropped: list[tuple[str, dict]]) -> str:
     total = sum(len(fr.get("findings", [])) for fr in file_findings.values())
@@ -422,7 +444,7 @@ def _build_summary_md(summary: dict, file_findings: dict, cross: dict,
     if summary.get("walkthrough"):
         out += ["### Walkthrough", summary["walkthrough"], ""]
     if summary.get("sequence_diagram"):
-        out += ["### Flow", "```mermaid", summary["sequence_diagram"], "```", ""]
+        out += ["### Flow", "```mermaid", _strip_code_fence(summary["sequence_diagram"]), "```", ""]
     if summary.get("suggested_reviewers_focus"):
         out += ["### Reviewer focus", summary["suggested_reviewers_focus"], ""]
 

--- a/ai-review-v2/src/orchestrator.py
+++ b/ai-review-v2/src/orchestrator.py
@@ -277,15 +277,46 @@ def _is_generated(content: str) -> bool:
 
 
 def _load_repo_conventions() -> str:
-    for name in ("CLAUDE.md", "AGENTS.md", ".cursorrules", ".windsurfrules",
-                 "CODESTYLE.md", "STYLEGUIDE.md", "CONTRIBUTING.md"):
+    """Load repo conventions from the first matching file.
+
+    Search order tries the most specific / most modern conventions first.
+    `.github/REVIEW.md` and `.github/AI_CONTEXT.md` are common patterns
+    from earlier AI-review tooling — pick them up so v2 inherits the
+    same context v1 did when consumers already maintained those.
+    """
+    candidates = (
+        # Modern, generic
+        "CLAUDE.md",
+        "AGENTS.md",
+        ".cursorrules",
+        ".windsurfrules",
+        # Review-specific policy (common from prior AI-review setups)
+        ".github/REVIEW.md",
+        ".github/AI_CONTEXT.md",
+        # Traditional style/contrib docs
+        "CODESTYLE.md",
+        "STYLEGUIDE.md",
+        "CONTRIBUTING.md",
+    )
+    parts: list[str] = []
+    budget = 8000
+    for name in candidates:
         p = Path(name)
-        if p.exists() and p.is_file():
-            try:
-                return p.read_text()[:8000]
-            except Exception:
-                continue
-    return ""
+        if not (p.exists() and p.is_file()):
+            continue
+        try:
+            text = p.read_text()
+        except Exception:
+            continue
+        # Concatenate up to the budget so a repo with both REVIEW.md AND
+        # AI_CONTEXT.md gets BOTH in the prompt, not just whichever wins
+        # the priority race.
+        remaining = budget - sum(len(s) for s in parts)
+        if remaining <= 200:
+            break
+        snippet = text[:remaining]
+        parts.append(f"\n\n## {name}\n\n{snippet}")
+    return "".join(parts).strip()
 
 
 def _match_path_instructions(path: str, cfg: Config) -> str:

--- a/ai-review-v2/src/orchestrator.py
+++ b/ai-review-v2/src/orchestrator.py
@@ -109,7 +109,11 @@ def review_pr(cfg: Config, conn: sqlite3.Connection) -> None:
             f"(lockfile bump / docs-only / generated). Push a substantive "
             f"commit to re-engage, or set `force-depth` to override.</sub>",
         )
-        _update_state(conn, cfg, files, prior.last_review_id if prior else None, "skip", 0)
+        # Record head_sha for idempotency but DO NOT mark per-file blob_shas as
+        # "reviewed" — they weren't. If we did, a later FORCE_DEPTH run (or a
+        # config change that flips the same diff into a real review) would
+        # filter every file out as "already reviewed since last time".
+        _update_state(conn, cfg, [], prior.last_review_id if prior else None, "skip", 0)
         return
 
     # === Pass 2: Static analyzers ===

--- a/ai-review-v2/src/orchestrator.py
+++ b/ai-review-v2/src/orchestrator.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import logging
+import os
 import sqlite3
 from pathlib import Path
 
@@ -30,6 +31,11 @@ log = logging.getLogger(__name__)
 
 
 SEVERITY_EMOJI = {"critical": "🔴", "major": "🟠", "minor": "🟡", "nit": "💭"}
+
+# Visible + hidden v2 branding so reviewers (and grep) can never confuse v2
+# output with v1's. Every comment/review v2 posts carries both.
+V2_BADGE = "🧪 **PR Reviewer v2**"
+V2_MARKER = "<!-- pr-reviewer-v2 -->"
 
 
 def review_pr(cfg: Config, conn: sqlite3.Connection) -> None:
@@ -86,10 +92,22 @@ def review_pr(cfg: Config, conn: sqlite3.Connection) -> None:
     focus_areas = triage.get("focus_areas") or []
     log.info("triage → depth=%s focus=%s", depth, focus_areas)
 
+    # Operator override: FORCE_DEPTH env var beats the triage result.
+    # Useful for evaluation runs, high-risk PRs, or debugging.
+    force_depth = (os.environ.get("FORCE_DEPTH") or "").strip().lower()
+    if force_depth in {"light", "standard", "deep"}:
+        if force_depth != depth:
+            log.info("FORCE_DEPTH=%s overriding triage depth=%s", force_depth, depth)
+        depth = force_depth
+
     if depth == "skip":
         github_api.post_pr_comment(
             cfg.github_repo, cfg.pr_number,
-            f"🤖 **Skipping review** — {triage.get('reasoning', '')}",
+            f"{V2_MARKER}\n{V2_BADGE} — _skipped by triage_\n\n"
+            f"> {triage.get('reasoning', '(no reason given)')}\n\n"
+            f"<sub>Triage skips only when the diff itself is trivial "
+            f"(lockfile bump / docs-only / generated). Push a substantive "
+            f"commit to re-engage, or set `force-depth` to override.</sub>",
         )
         _update_state(conn, cfg, files, prior.last_review_id if prior else None, "skip", 0)
         return
@@ -338,18 +356,49 @@ def _post_review(
 
 
 def _format_finding(f: dict, prefix: str = "") -> str:
-    emoji = SEVERITY_EMOJI.get(f.get("severity", ""), "")
-    header = (f"{emoji} **{prefix}{(f.get('severity') or '').upper()} · "
-              f"{f.get('category', '')}** · confidence {f.get('confidence', '?')}/5")
-    parts = [header, f"### {f.get('title', '')}", f.get("body", "")]
+    """Render an inline finding with clear sections and a one-click suggestion.
+
+    Output structure:
+        <hidden v2 marker>
+        🧪 **PR Reviewer v2** · 🔴 **CRITICAL · security** · confidence 5/5
+        ### {prefix}Title
+
+        {body}                          ← markdown allowed: bold, code, bullets
+
+        **Suggested fix**
+        ```suggestion
+        {code GitHub will offer as one-click "Commit suggestion"}
+        ```
+    """
+    sev = (f.get("severity") or "").lower()
+    cat = (f.get("category") or "").lower()
+    conf = f.get("confidence", "?")
+    sev_emoji = SEVERITY_EMOJI.get(sev, "")
+    title = (f.get("title") or "").strip()
+    body = (f.get("body") or "").strip()
+
+    header = (
+        f"{V2_MARKER}\n"
+        f"{V2_BADGE} · {sev_emoji} **{sev.upper() or 'FINDING'}"
+        f"{' · ' + cat if cat else ''}** · confidence {conf}/5"
+    )
+    parts: list[str] = [header]
+    if title:
+        parts.append(f"### {prefix}{title}")
+    if body:
+        parts.append(body)
+
     sug = f.get("suggestion")
-    if sug and isinstance(sug, str) and sug.strip():
+    if isinstance(sug, str) and sug.strip():
         sug = sug.strip()
-        if not sug.startswith("```"):
-            parts.append(f"```suggestion\n{sug}\n```")
-        else:
-            parts.append(sug)
-    return "\n\n".join(p for p in parts if p)
+        # If the model already wrapped it in a ```suggestion fence, keep as-is.
+        # Otherwise wrap so GitHub renders the one-click "Commit suggestion" UI.
+        already_fenced = sug.startswith("```suggestion")
+        suggestion_block = sug if already_fenced else f"```suggestion\n{sug}\n```"
+        parts.append("**Suggested fix** _(click \"Commit suggestion\" to accept)_")
+        parts.append(suggestion_block)
+
+    return "\n\n".join(parts)
 
 
 def _build_summary_md(summary: dict, file_findings: dict, cross: dict,
@@ -357,9 +406,15 @@ def _build_summary_md(summary: dict, file_findings: dict, cross: dict,
     total = sum(len(fr.get("findings", [])) for fr in file_findings.values())
     cross_list = cross.get("cross_cutting_findings", [])
 
-    out = ["## 🤖 Automated Review", ""]
+    out = [
+        V2_MARKER,
+        "## 🧪 PR Reviewer v2",
+        "_LLM-agnostic reviewer with codegraph, learnings, and incremental "
+        "state. Distinct from the existing v1 `ai-review` action._",
+        "",
+    ]
     if summary.get("tldr"):
-        out += [f"**{summary['tldr']}**", ""]
+        out += [f"**TL;DR.** {summary['tldr']}", ""]
     if summary.get("walkthrough"):
         out += ["### Walkthrough", summary["walkthrough"], ""]
     if summary.get("sequence_diagram"):

--- a/ai-review-v2/src/prompts.py
+++ b/ai-review-v2/src/prompts.py
@@ -110,7 +110,7 @@ Output JSON:
 {{
   "tldr": "2-3 sentences. What does this change do, factually? Concrete verbs, no 'this PR adds support for'.",
   "walkthrough": "Markdown table | File | Change |. One row per significant file. 'Adds exponential-backoff retry in fetch_user()' not 'Updates user fetching'.",
-  "sequence_diagram": "Mermaid sequenceDiagram code IF the PR introduces a new multi-component interaction. Else null.",
+  "sequence_diagram": "Mermaid sequenceDiagram source IF the PR introduces a new multi-component interaction; else null. Output the raw mermaid source ONLY (start with the literal text `sequenceDiagram`). DO NOT wrap it in ```mermaid fences — the wrapper adds those.",
   "risk_areas": ["short phrases naming risky parts"],
   "suggested_reviewers_focus": "1-2 sentences telling a human reviewer where to spend attention."
 }}"""

--- a/ai-review-v2/src/prompts.py
+++ b/ai-review-v2/src/prompts.py
@@ -25,6 +25,11 @@ if TYPE_CHECKING:
 
 TRIAGE_SYSTEM = """You triage pull requests to decide how much review effort they deserve.
 
+Your decision MUST be based on the FILES CHANGED — what code is touched, how
+much, and where. Do NOT base "skip" on the PR title or description alone. Authors
+routinely write "test", "WIP", "DO NOT MERGE", "evaluation", "ignore me", etc. on
+PRs that contain real, production-shape code; those PRs still need a review.
+
 Output JSON only. Be terse — no prose outside the JSON."""
 
 
@@ -34,24 +39,33 @@ def triage_user(pr: dict, files: list) -> str:
         for f in files[:60]
     )
     extra = f"\n  ... and {len(files) - 60} more files" if len(files) > 60 else ""
-    return f"""PR Title: {pr.get('title', '')}
+    return f"""PR Title (context only — do not use this to decide skip): {pr.get('title', '')}
 
-PR Description:
+PR Description (context only — do not use this to decide skip):
 {(pr.get('body') or '(none)')[:2000]}
 
-Files changed ({len(files)} total):
+Files changed ({len(files)} total) — THIS is what you triage on:
 {file_lines}{extra}
 
 Output JSON exactly:
 {{
   "depth": "skip" | "light" | "standard" | "deep",
-  "reasoning": "one sentence",
+  "reasoning": "one sentence citing the FILES, not the title/body",
   "focus_areas": ["security" | "performance" | "correctness" | "concurrency" | "tests" | "api_design" | "error_handling"]
 }}
 
-Rules:
-- skip:     docs-only, generated files only, lockfile/dependency bumps only, version bumps
-- light:    <60 net lines, single isolated file, test-only additions, trivial refactor
+Rules — apply to the FILES CHANGED, never to the PR title/body:
+
+- skip: every changed file is ONE of:
+    * a lockfile (package-lock.json, yarn.lock, poetry.lock, go.sum, Cargo.lock, ...)
+    * pure documentation (*.md, *.rst, *.txt, docs/**)
+    * generated code (header says "@generated" / "DO NOT EDIT" / "auto-generated")
+    * a version bump in a manifest with no source change
+  DO NOT skip just because the PR title says "test", "WIP", "DO NOT MERGE",
+  "evaluation", "throwaway", etc. If even ONE file contains substantive source
+  code (a real .py / .ts / .go / .rs / etc. file with logic), use light/standard/deep.
+
+- light:    <60 net source lines, single isolated file, test-only additions, trivial refactor
 - standard: typical feature work or bug fix
 - deep:     >500 net lines, OR auth/crypto/payments/IAM/SQL/migrations,
             OR breaking API change, OR introduces concurrency primitives,
@@ -121,6 +135,29 @@ Strict rules:
 6. No hedging ("this could potentially...") — if not a real problem, omit it.
 7. No restating what the code does. Findings are about what's wrong.
 8. If the file is fine, return an empty findings array. Empty is valid.
+
+Formatting rules for `body` (rendered as Markdown in a GitHub PR comment):
+- Structure it as three short labelled paragraphs, in this order:
+    **Problem.** One sentence naming what's wrong.
+    **Why it matters.** One or two sentences on concrete consequences in THIS
+      codebase / on THIS code path — not generic textbook risk.
+    **Fix.** One sentence describing the intended change at a high level.
+- Use inline backticks for identifiers, e.g. `find_user_by_email`, `out=[]`.
+- Use a fenced code block (```) to quote SHORT snippets only when it clarifies.
+- No emojis in `body` (the surrounding template adds them).
+- Keep total `body` length under ~600 characters.
+
+Formatting rules for `suggestion` (rendered as a GitHub `suggestion` block,
+which lets the reviewer click "Commit suggestion" to accept):
+- Provide a `suggestion` whenever the fix is mechanical and fits on the cited
+  lines (e.g. parameterize a SQL query, change `==` to `is`, replace `out=[]`
+  with `out=None` + body check, replace bare `except:` with `except Exception:`).
+- The suggestion must be the EXACT replacement text for the cited lines
+  (from `line` through `end_line`), with the same indentation as the original.
+- Do NOT include `'''suggestion` fences — the wrapper adds them. Just the code.
+- If a clean mechanical replacement is not possible (cross-cutting refactor,
+  needs new helper, design discussion), set `suggestion` to null and explain
+  the fix in `body` only. Do not invent half-suggestions.
 
 Output JSON only."""
 
@@ -223,8 +260,8 @@ Output JSON exactly:
       "category": "bug" | "security" | "performance" | "concurrency" | "error_handling" | "api_design" | "testing" | "maintainability",
       "confidence": <1-5>,
       "title": "Short headline (max 80 chars). State the problem.",
-      "body": "Markdown. What's wrong, why it matters HERE, what happens if not fixed.",
-      "suggestion": "<replacement code for cited lines, plain text, or null>"
+      "body": "Markdown body, structured as **Problem.** / **Why it matters.** / **Fix.** paragraphs. See system prompt.",
+      "suggestion": "<exact replacement text for lines [line..end_line], same indentation, NO ```suggestion fences. null if not mechanically replaceable.>"
     }}
   ]
 }}"""

--- a/ai-review-v2/src/prompts.py
+++ b/ai-review-v2/src/prompts.py
@@ -1,0 +1,366 @@
+"""Prompts for the review pipeline. Tune here.
+
+Design notes:
+- Per-file prompt now has three context-injection slots: STATIC ANALYSIS,
+  CODEGRAPH (cross-file callers), and LEARNINGS (team preferences).
+- The "DO NOT FLAG" list explicitly references all three, so the model knows
+  not to repeat them.
+- Numeric confidence 1-5 forces models out of squishy hedges into a filterable signal.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .codegraph import CodegraphContext
+    from .github_api import ChangedFile
+    from .knowledge import Learning
+
+
+# ============================================================
+# TRIAGE
+# ============================================================
+
+TRIAGE_SYSTEM = """You triage pull requests to decide how much review effort they deserve.
+
+Output JSON only. Be terse — no prose outside the JSON."""
+
+
+def triage_user(pr: dict, files: list) -> str:
+    file_lines = "\n".join(
+        f"  {f.status:8s} +{f.additions:<5d} -{f.deletions:<5d}  {f.path}"
+        for f in files[:60]
+    )
+    extra = f"\n  ... and {len(files) - 60} more files" if len(files) > 60 else ""
+    return f"""PR Title: {pr.get('title', '')}
+
+PR Description:
+{(pr.get('body') or '(none)')[:2000]}
+
+Files changed ({len(files)} total):
+{file_lines}{extra}
+
+Output JSON exactly:
+{{
+  "depth": "skip" | "light" | "standard" | "deep",
+  "reasoning": "one sentence",
+  "focus_areas": ["security" | "performance" | "correctness" | "concurrency" | "tests" | "api_design" | "error_handling"]
+}}
+
+Rules:
+- skip:     docs-only, generated files only, lockfile/dependency bumps only, version bumps
+- light:    <60 net lines, single isolated file, test-only additions, trivial refactor
+- standard: typical feature work or bug fix
+- deep:     >500 net lines, OR auth/crypto/payments/IAM/SQL/migrations,
+            OR breaking API change, OR introduces concurrency primitives,
+            OR path contains "security" / "auth"
+
+Pick 1-4 focus_areas. Empty list is fine for trivial PRs."""
+
+
+# ============================================================
+# SUMMARY
+# ============================================================
+
+SUMMARY_SYSTEM = """You write PR summaries for code reviewers.
+
+Be specific. State what the change does in concrete terms. No marketing fluff,
+no "this PR" boilerplate, no restating the title. Reviewers are smart and busy.
+
+Output JSON only."""
+
+
+def summary_user(pr: dict, files: list, conventions: str, ci_logs: str = "") -> str:
+    file_lines = "\n".join(f"- `{f.path}` (+{f.additions}/-{f.deletions}) [{f.status}]" for f in files)
+    diffs = "\n\n".join(
+        f"### {f.path}\n```diff\n{f.diff[:3500]}\n```"
+        for f in files[:20]
+        if f.diff
+    )
+    conv = f"\n\nREPO CONVENTIONS:\n{conventions[:3000]}" if conventions else ""
+    ci = f"\n\nFAILED CI LOGS (tail):\n{ci_logs[:4000]}" if ci_logs else ""
+    return f"""PR Title: {pr.get('title', '')}
+
+Description:
+{(pr.get('body') or '(none)')[:3000]}
+
+Files:
+{file_lines}
+
+Diffs (truncated per file):
+{diffs[:14000]}{conv}{ci}
+
+Output JSON:
+{{
+  "tldr": "2-3 sentences. What does this change do, factually? Concrete verbs, no 'this PR adds support for'.",
+  "walkthrough": "Markdown table | File | Change |. One row per significant file. 'Adds exponential-backoff retry in fetch_user()' not 'Updates user fetching'.",
+  "sequence_diagram": "Mermaid sequenceDiagram code IF the PR introduces a new multi-component interaction. Else null.",
+  "risk_areas": ["short phrases naming risky parts"],
+  "suggested_reviewers_focus": "1-2 sentences telling a human reviewer where to spend attention."
+}}"""
+
+
+# ============================================================
+# PER-FILE REVIEW (the workhorse)
+# ============================================================
+
+FILE_REVIEW_SYSTEM = """You are a senior engineer reviewing ONE file in a pull request.
+
+Your job is to find real problems. The reviewer's attention is the scarce resource.
+A review with one true bug and zero noise is far more valuable than five findings
+where four are speculation.
+
+Strict rules:
+1. Only flag issues you would bet money on being correct.
+2. Cite EXACT line numbers from the numbered listing in the user message.
+3. Never repeat what STATIC ANALYSIS, CODEGRAPH, or LEARNINGS already cover.
+4. No style, formatting, or naming nits.
+5. No "consider extracting" without a concrete reason.
+6. No hedging ("this could potentially...") — if not a real problem, omit it.
+7. No restating what the code does. Findings are about what's wrong.
+8. If the file is fine, return an empty findings array. Empty is valid.
+
+Output JSON only."""
+
+
+def file_review_user(
+    f: "ChangedFile",
+    pr: dict,
+    conventions: str,
+    focus_areas: list[str],
+    codegraph_block: str = "",
+    learnings: list["Learning"] | None = None,
+    path_instructions: str = "",
+) -> str:
+    new_content = f.new_content or ""
+    numbered = "\n".join(
+        f"{i + 1:5d}  {line}" for i, line in enumerate(new_content.splitlines())
+    )[:60000]
+    old = (f.old_content or "")[:18000] if f.old_content else ""
+
+    old_block = (
+        f"PREVIOUS VERSION OF FILE (for reference; do NOT cite these line numbers):\n"
+        f"```{f.language}\n{old}\n```\n\n"
+        if old
+        else ""
+    )
+
+    analyzer = f.analyzer_output.strip() or "(no static analyzer findings for this file)"
+
+    conv_block = f"REPO CONVENTIONS:\n{conventions[:4000]}\n\n" if conventions else ""
+
+    learn_block = ""
+    if learnings:
+        lines = [f"  [#{l.id}] {l.description.strip()}" for l in learnings]
+        learn_block = (
+            "TEAM LEARNINGS (preferences captured from prior reviews — respect these):\n"
+            + "\n".join(lines) + "\n\n"
+        )
+
+    path_block = (
+        f"PATH-SPECIFIC INSTRUCTIONS (this file matched a configured rule):\n{path_instructions}\n\n"
+        if path_instructions else ""
+    )
+
+    cg_block = f"{codegraph_block}\n\n" if codegraph_block else ""
+
+    focus = ", ".join(focus_areas) if focus_areas else "general correctness"
+
+    return f"""{conv_block}{learn_block}{path_block}PR CONTEXT:
+Title: {pr.get('title', '')}
+Description: {(pr.get('body') or '(none)')[:1500]}
+Focus areas (from triage): {focus}
+
+FILE: {f.path}
+Language: {f.language or 'unknown'}
+Status: {f.status}
+
+STATIC ANALYSIS already covered for this file (do NOT re-flag these):
+{analyzer}
+
+{cg_block}{old_block}CURRENT FILE (line numbers in the leftmost column — these are what you cite in `line`):
+```{f.language}
+{numbered}
+```
+
+DIFF for this file:
+```diff
+{f.diff[:8000]}
+```
+
+PRIORITIZE finding:
+- Logic bugs: off-by-one, wrong operator, swapped arguments, inverted condition
+- Null/None/undefined access on values that can be that type
+- Race conditions, unsafe shared state, missing locks, goroutine/task leaks
+- Resource leaks: unclosed files, sockets, transactions, contexts, subscriptions
+- Injection: SQL, command, path traversal, SSRF, unsafe deserialization, XSS
+- Auth/authz: new endpoint without permission check, IDOR, missing tenant scoping
+- Missing error handling on operations that fail
+- N+1 queries, unbounded loops over user input, accidental O(n^2) on hot paths
+- Breaking changes to exported/public APIs without migration
+- New conditional branches with no test coverage
+- Inconsistency with patterns visible elsewhere IN THIS FILE
+- Mismatches with the CODEGRAPH callers shown above (e.g. signature change here breaks callers)
+
+DO NOT flag:
+- Anything in STATIC ANALYSIS, CODEGRAPH, LEARNINGS, or PATH INSTRUCTIONS above
+- Style, formatting, naming, import order
+- Missing docstrings/comments unless on a public API
+- Hypothetical issues without evidence
+- "Could be cleaner" without a specific concrete fix
+- Things that depend on code outside this file and outside the CODEGRAPH callers shown
+
+Output JSON exactly:
+{{
+  "file_summary": "1-2 sentences on what changed in THIS file.",
+  "findings": [
+    {{
+      "line": <int from CURRENT FILE>,
+      "end_line": <int or null>,
+      "severity": "critical" | "major" | "minor" | "nit",
+      "category": "bug" | "security" | "performance" | "concurrency" | "error_handling" | "api_design" | "testing" | "maintainability",
+      "confidence": <1-5>,
+      "title": "Short headline (max 80 chars). State the problem.",
+      "body": "Markdown. What's wrong, why it matters HERE, what happens if not fixed.",
+      "suggestion": "<replacement code for cited lines, plain text, or null>"
+    }}
+  ]
+}}"""
+
+
+# ============================================================
+# CROSS-CUTTING
+# ============================================================
+
+CROSS_CUT_SYSTEM = """You're doing the final pass on a PR after each file has been
+reviewed individually.
+
+Your job: find issues that need the WHOLE PR in view to spot. Do NOT repeat
+per-file findings — those are already posted.
+
+Be very selective. Empty findings is fine. Output JSON only."""
+
+
+def cross_cut_user(
+    pr: dict,
+    summary: dict,
+    file_findings: dict,
+    files: list,
+) -> str:
+    digest = json.dumps(
+        {
+            path: {
+                "file_summary": fr.get("file_summary", ""),
+                "findings": [
+                    {
+                        "line": x.get("line"),
+                        "severity": x.get("severity"),
+                        "category": x.get("category"),
+                        "title": x.get("title"),
+                    }
+                    for x in fr.get("findings", [])
+                ],
+            }
+            for path, fr in file_findings.items()
+        },
+        indent=2,
+    )[:15000]
+
+    return f"""PR Title: {pr.get('title', '')}
+
+Summary TL;DR:
+{summary.get('tldr', '')}
+
+Files in PR: {[f.path for f in files]}
+
+Per-file review digest (titles only):
+{digest}
+
+Look for things that require seeing the whole PR:
+- Caller-callee mismatch across files
+- New public endpoint or handler with NO auth check anywhere in the PR
+- Behavior added across files but NO tests added
+- Feature flag with no rollback path
+- Migration without backwards-compat
+- Inconsistent error handling between new and existing code
+- Imports added but never used, exports defined but never imported
+- Performance regression from combined changes
+
+Output JSON:
+{{
+  "cross_cutting_findings": [
+    {{
+      "file": "<path>" | null,
+      "line": <int or null>,
+      "severity": "critical" | "major" | "minor",
+      "category": "...",
+      "confidence": <1-5>,
+      "title": "...",
+      "body": "Markdown."
+    }}
+  ],
+  "verdict": "approve" | "comment" | "request_changes",
+  "verdict_reasoning": "one sentence"
+}}
+
+Verdict rules:
+- request_changes: any critical OR multiple high-confidence major findings
+- comment: findings present but none critical
+- approve: no findings worth a human's time"""
+
+
+# ============================================================
+# LEARNING EXTRACTION (called by learn.py when user @-mentions the bot)
+# ============================================================
+
+LEARNING_EXTRACT_SYSTEM = """You decide whether a user comment should be saved as a
+durable team-wide review preference (a "learning").
+
+You receive a PR comment thread where someone has @-mentioned the bot, usually in
+reply to a review comment. Your job:
+
+1. Decide if this reply expresses a TEAM PREFERENCE (durable, applies to future PRs)
+   vs a ONE-OFF (specific to this PR only, e.g. "ignore this for now").
+2. If it's a team preference, extract a concise self-instructive learning that
+   captures the WHY, not just the WHAT.
+3. Identify the file pattern (gitignore-style) the learning should apply to,
+   if the context implies one.
+
+Output JSON only."""
+
+
+def learning_extract_user(
+    pr_title: str,
+    file_path: str | None,
+    parent_review_comment: str,
+    user_reply: str,
+    repo: str,
+) -> str:
+    return f"""Repository: {repo}
+PR: {pr_title}
+File the original comment was on: {file_path or '(general PR comment)'}
+
+REVIEWER'S ORIGINAL COMMENT (what the user is responding to):
+{parent_review_comment[:2000]}
+
+USER'S REPLY (decide if this should become a learning):
+{user_reply[:2000]}
+
+Output JSON:
+{{
+  "is_learning": <bool>,
+  "reasoning": "one sentence justifying yes/no",
+  "description": "<the learning, written as a self-instructive sentence for a future reviewer, capturing the why. e.g. 'In authentication middleware, prefer early returns with specific error codes over nested try-catch because they're easier to monitor in production.' Null if is_learning=false.>",
+  "scope": "repo" | "org" | null,
+  "file_pattern": "<gitignore-style glob if the learning is scoped to specific files, e.g. 'src/auth/**', else null>"
+}}
+
+Rules:
+- If the user is just acknowledging or thanking, is_learning=false.
+- If the user is correcting a one-time mistake specific to this PR, is_learning=false.
+- If the user explains a CONVENTION or PREFERENCE that applies to future code, is_learning=true.
+- Default scope is 'repo'. Use 'org' only if the user explicitly says it's an organization-wide rule.
+- Capture the why. "Don't suggest X" is weaker than "Don't suggest X because Y."
+"""

--- a/ai-review-v2/tests/test_basics.py
+++ b/ai-review-v2/tests/test_basics.py
@@ -1,0 +1,130 @@
+"""Skeletal tests. Run with: pytest tests/
+
+These aren't a comprehensive suite — they're a starting point. The functions
+most worth covering as you iterate:
+  - parse_diff_new_lines (correctness against weird diff formats)
+  - parse_json (provider quirks)
+  - codegraph.extract_symbols (per language)
+  - knowledge.search_learnings (vector recall)
+"""
+
+import pytest
+
+from src.github_api import parse_diff_new_lines
+from src.llm import parse_json
+
+
+# ============================================================
+# parse_diff_new_lines
+# ============================================================
+
+def test_parse_diff_basic():
+    diff = """@@ -1,3 +1,4 @@
+ def foo():
++    new_line()
+     return 1
+ # end
+"""
+    assert parse_diff_new_lines(diff) == {2}
+
+
+def test_parse_diff_multiple_hunks():
+    diff = """@@ -1,2 +1,3 @@
+ a
++b
+ c
+@@ -10,2 +11,3 @@
+ x
++y
+ z
+"""
+    lines = parse_diff_new_lines(diff)
+    assert 2 in lines
+    assert 12 in lines
+
+
+def test_parse_diff_no_count():
+    # Single-line hunk format: @@ -1 +1 @@
+    diff = """@@ -1 +1 @@
+-old
++new
+"""
+    assert parse_diff_new_lines(diff) == {1}
+
+
+# ============================================================
+# parse_json
+# ============================================================
+
+def test_parse_json_clean():
+    assert parse_json('{"a": 1}') == {"a": 1}
+
+
+def test_parse_json_code_fence():
+    assert parse_json('```json\n{"a": 1}\n```') == {"a": 1}
+
+
+def test_parse_json_with_preamble():
+    s = 'Here is the result:\n{"x": [1, 2]}\nDone.'
+    assert parse_json(s) == {"x": [1, 2]}
+
+
+def test_parse_json_garbage():
+    assert parse_json("no json here") == {}
+
+
+def test_parse_json_nested():
+    s = '{"outer": {"inner": "value"}, "list": [1, 2, 3]}'
+    assert parse_json(s) == {"outer": {"inner": "value"}, "list": [1, 2, 3]}
+
+
+# ============================================================
+# Codegraph (requires tree-sitter — skip if missing)
+# ============================================================
+
+def test_extract_python_symbols():
+    pytest.importorskip("tree_sitter_languages")
+    from src.codegraph import extract_symbols
+
+    code = """
+def alpha():
+    pass
+
+class Beta:
+    def method(self):
+        pass
+"""
+    syms = extract_symbols(code, "python")
+    names = {s.name for s in syms}
+    assert "alpha" in names
+    assert "Beta" in names
+    assert "method" in names
+
+
+def test_extract_typescript_symbols():
+    pytest.importorskip("tree_sitter_languages")
+    from src.codegraph import extract_symbols
+
+    code = """
+export function fetchUser(id: string) { return null; }
+export class UserService {
+  async load() {}
+}
+"""
+    syms = extract_symbols(code, "typescript")
+    names = {s.name for s in syms}
+    assert "fetchUser" in names
+    assert "UserService" in names
+    assert "load" in names
+
+
+# ============================================================
+# Path instruction matching
+# ============================================================
+
+def test_path_matching():
+    import pathspec
+    spec = pathspec.PathSpec.from_lines("gitwildmatch", ["src/api/**"])
+    assert spec.match_file("src/api/handlers.py")
+    assert spec.match_file("src/api/v2/users.py")
+    assert not spec.match_file("src/lib/util.py")

--- a/ai-review-v2/workflows/learn.yml
+++ b/ai-review-v2/workflows/learn.yml
@@ -1,0 +1,25 @@
+name: Learn from Comments
+on:
+  issue_comment:
+    types: [created, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+
+permissions:
+  contents: write          # for state branch
+  pull-requests: write     # to reply
+
+jobs:
+  learn:
+    # Only run if the comment is on a PR (not a plain issue) and mentions the bot
+    if: |
+      github.event.issue.pull_request != null ||
+      github.event_name == 'pull_request_review_comment'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: your-org/pr-review-action-v2@v2
+        with:
+          mode: learn
+          review-api-key: ${{ secrets.OPENAI_API_KEY }}
+          review-model: gpt-4o-mini   # extract is cheap
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/ai-review-v2/workflows/review.yml
+++ b/ai-review-v2/workflows/review.yml
@@ -1,0 +1,50 @@
+name: PR Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write          # required to push to the state branch
+  pull-requests: write
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: your-org/pr-review-action-v2@v2
+        with:
+          mode: review
+
+          # --- Pick ONE provider config ---
+
+          # OpenAI
+          review-api-key: ${{ secrets.OPENAI_API_KEY }}
+          review-model: gpt-4o
+          triage-model: gpt-4o-mini
+
+          # Anthropic (OpenAI-compat layer). Note: Anthropic has no /v1/embeddings,
+          # so embed-* must point at OpenAI or Voyage if you use Claude here.
+          # review-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # review-base-url: https://api.anthropic.com/v1
+          # review-model: claude-opus-4-7
+          # embed-api-key: ${{ secrets.OPENAI_API_KEY }}
+          # embed-base-url: https://api.openai.com/v1
+          # embed-model: text-embedding-3-small
+
+          # DeepSeek (cheap, supports embeddings)
+          # review-api-key: ${{ secrets.DEEPSEEK_API_KEY }}
+          # review-base-url: https://api.deepseek.com/v1
+          # review-model: deepseek-chat
+
+          # Behavior
+          confidence-threshold: '3'
+          enable-codegraph: 'true'
+          enable-learnings: 'true'
+          enable-incremental: 'true'
+
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds **`ai-review-v2`** — a self-hosted, LLM-agnostic AI PR reviewer designed to deliver CodeRabbit-class reviews without per-seat pricing. Lives at `ai-review-v2/` so it can be consumed as `tildabio/actions/ai-review-v2@<ref>` alongside the existing v1 action (which we'll keep around during the transition).

Cost target: **~\$0.20/PR on Claude Sonnet, ~\$0.012/PR on DeepSeek** vs. CodeRabbit's per-seat pricing. State + telemetry live on an orphan branch (`__reviewer_state__`) in the consumer repo — zero external infrastructure.

## What's in the box

```
ai-review-v2/
  action.yml              GitHub composite action entry point
  pyproject.toml          Dependencies (openai, tree-sitter, sqlite-vec, ...)
  schema.sql              SQLite schema for state + learnings
  README.md               Full operator docs
  .review.yaml.example    Per-repo path-based instructions template
  src/                    The pipeline
    __main__.py             CLI dispatcher (review | learn)
    config.py               Env + .review.yaml loader
    prompts.py              All prompts (the high-leverage tuning file)
    orchestrator.py         7-pass review pipeline
    llm.py                  OpenAI-compatible chat + embeddings client
    github_api.py           gh CLI wrappers + state-branch sync
    analyzers.py            ruff/semgrep/bandit subprocess runners
    codegraph.py            Tree-sitter symbols + ripgrep callers
    knowledge.py            SQLite + sqlite-vec helpers
    learn.py                @reviewer mention listener
  tests/                  Starter test coverage
  workflows/              Reference consumer workflow files
```

## Architecture (7-pass pipeline)

```
PR opened → action checks out PR head → state.db cloned from orphan branch
   │
   ▼
1. Idempotency      skip if head_sha already reviewed
2. Incremental      filter to files whose blob_sha changed
3. Triage           cheap model decides skip|light|standard|deep
4. Analyzers        ruff/semgrep/bandit (no LLM)
5. Codegraph        tree-sitter symbols + ripgrep external callers
6. Learnings        embed file → vec MATCH against learnings_vec
7. Summary          smart model, 1 call, with CI logs
8. Per-file review  smart model, N parallel calls (prompt includes
                    analyzer output, codegraph callers, learnings,
                    path instructions)
9. Cross-cut        smart model, 1 call, verdict
10. Filter by confidence threshold
11. Post single GitHub Review (inline + summary)
   │
   ▼
state pushed back to __reviewer_state__ (pull-rebase loop on conflict)
```

Separate `mode: learn` workflow listens for `@reviewer` mentions on PR comments, extracts durable team preferences, embeds them, and persists them so future reviews retrieve them via vec MATCH.

## Validation

Tested end-to-end on tildabio/main during development. Most recently exercised on **[tildabio/main#13277](https://github.com/tildabio/main/pull/13277)** — a mirror of @krishnaatluru-cpu's real docproc fix ([tildabio/main#13260](https://github.com/tildabio/main/pull/13260)) with v2 attached. Results:
- Triage correctly classified as `standard` with focus `[error_handling, correctness, api_design]`
- Codegraph found callers for 3/5 files
- 0 false positives on the 3 actual docproc Python files (clean code per v2)
- Generated a rendered mermaid sequence diagram of the fix's flow
- Pipeline cost: ~\$0.15 in Anthropic + a few cents of OpenAI embeddings

The learnings loop was also exercised: a real `@reviewer` reply about parameterized SQL was extracted, embedded, persisted, then **retrieved on the next review** (visible in the orchestrator log: `learnings retrieved: 1 total across files`) and successfully suppressed a related repeat finding.

## Bug fixes in this branch (post-initial-import)

Discovered and fixed during the end-to-end evaluation:
- `config.py`: empty-string env vars from GitHub Actions fallbacks fixed (\`or\` instead of \`get(..., default)\`)
- `prompts.py`: triage no longer skips on PR title/body markers (\"test\", \"DO NOT MERGE\"); only file content matters
- `prompts.py` + `orchestrator.py`: branded every artifact with `<!-- pr-reviewer-v2 -->` marker + visible badge for unambiguous v1-vs-v2 distinction
- `prompts.py`: structured finding bodies (Problem / Why / Fix) + mandatory `suggestion` blocks for mechanical fixes
- `orchestrator.py`: skip path no longer poisons `reviewed_files` state
- `action.yml`: run from `github.workspace` (not `action_path`) so `git show` finds the consumer repo
- `action.yml`: `python -P` + explicit `PYTHONPATH` so consumer's own `src/` doesn't shadow the action's package
- `knowledge.py`: `check_same_thread=False` on the SQLite connection (per-file pool uses worker threads)
- `knowledge.py`: vec0 KNN query needs `AND k = ?` (not just `LIMIT`)
- `github_api.py`: resilient review submission with split fallback on 422; auto-downgrade `REQUEST_CHANGES` → `COMMENT` on self-PR
- `learn.py`: skip self-bot comments via marker (was username-based, missed PAT case); case-insensitive `@reviewer` mention check
- `orchestrator.py`: strip LLM-supplied code fence on `sequence_diagram` so mermaid actually renders

## Adoption path

1. Merge this PR — `ai-review-v2/` is now consumable as `tildabio/actions/ai-review-v2@main`.
2. Tag a semver release (e.g. `v2.0.0`) so consumer workflows can pin to a tag rather than a branch.
3. Roll out to one repo (suggest `tildabio/main`) by adding the example workflows in `ai-review-v2/workflows/` to `.github/workflows/`. Add `ANTHROPIC_API_KEY` + `OPENAI_API_KEY` (embeddings) secrets.
4. Run for a week, tune `prompts.py` based on observed false positives.
5. Disable the existing v1 `ai-review` workflow once v2 is producing better output.

## Notes for review

- The 12 fix commits on this branch make the history dense — happy to squash on merge.
- The v2 action coexists with v1 (`ai-review/`). Consumers can run both during transition; v2's `<!-- pr-reviewer-v2 -->` marker keeps the output unambiguous.
- `pyproject.toml` doesn't fully configure setuptools auto-discovery; we work around it via explicit `PYTHONPATH` in `action.yml`. Worth fixing in a follow-up.
- The Anthropic OpenAI-compat endpoint emits a 400 on the first request of each chat call, then succeeds on retry. Tenacity handles it. Worth investigating separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)