### PR TITLE
fix(build-and-push): registry layer cache instead of over-limit GHA cache

### DIFF
--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -113,9 +113,11 @@ runs:
         # reuse -> 0% hits. Registry cache has no such cap and is shared across
         # branches. image-manifest/oci-mediatypes are required for GAR.
         # Only WRITE on push builds (PR/dependabot builds lack push creds); all
-        # builds READ the shared cache.
+        # builds READ the shared cache. ignore-error=true makes a cache-export
+        # failure non-fatal — the build always succeeds, so the worst case is
+        # "no caching" (today's behaviour), never a broken pipeline.
         cache-from: ${{ inputs.cache == 'true' && format('type=registry,ref={0}/{1}/artifacts/services/{2}:buildcache', inputs.artifactory-url, inputs.google-project, inputs.service-name) || '' }}
-        cache-to: ${{ inputs.cache == 'true' && inputs.push == 'true' && format('type=registry,ref={0}/{1}/artifacts/services/{2}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', inputs.artifactory-url, inputs.google-project, inputs.service-name) || '' }}
+        cache-to: ${{ inputs.cache == 'true' && inputs.push == 'true' && format('type=registry,ref={0}/{1}/artifacts/services/{2}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true', inputs.artifactory-url, inputs.google-project, inputs.service-name) || '' }}
 
     - name: Summarize
       shell: bash

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -1,6 +1,6 @@
 name: "Build and Push to Google Artifactory"
 description: >
-  Build a docker container with buildx + GitHub Actions cache and optionally
+  Build a docker container with buildx + registry-backed layer cache and optionally
   publish it to Google Artifact Registry. Caller is responsible for checking
   out the repository before invoking this action.
 inputs:
@@ -107,8 +107,15 @@ runs:
         build-args: |
           BUILDARG_VERSION=${{ steps.meta.outputs.version }}
           ${{ inputs.build_args }}
-        cache-from: ${{ inputs.cache == 'true' && format('type=gha,scope={0}', inputs.cache-scope != '' && inputs.cache-scope || inputs.service-name) || '' }}
-        cache-to: ${{ inputs.cache == 'true' && format('type=gha,mode=max,scope={0}', inputs.cache-scope != '' && inputs.cache-scope || inputs.service-name) || '' }}
+        # Registry-backed layer cache (one :buildcache tag per service repo).
+        # Replaces type=gha, which was over GitHub's 10 GB Actions-cache limit
+        # (~20 services x mode=max ~= 12+ GB) so caches were LRU-evicted before
+        # reuse -> 0% hits. Registry cache has no such cap and is shared across
+        # branches. image-manifest/oci-mediatypes are required for GAR.
+        # Only WRITE on push builds (PR/dependabot builds lack push creds); all
+        # builds READ the shared cache.
+        cache-from: ${{ inputs.cache == 'true' && format('type=registry,ref={0}/{1}/artifacts/services/{2}:buildcache', inputs.artifactory-url, inputs.google-project, inputs.service-name) || '' }}
+        cache-to: ${{ inputs.cache == 'true' && inputs.push == 'true' && format('type=registry,ref={0}/{1}/artifacts/services/{2}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true', inputs.artifactory-url, inputs.google-project, inputs.service-name) || '' }}
 
     - name: Summarize
       shell: bash
@@ -119,5 +126,5 @@ runs:
           echo "- **Image**: \`${{ steps.meta.outputs.tags }}\`"
           echo "- **Digest**: \`${{ steps.build.outputs.digest }}\`"
           echo "- **Pushed**: \`${{ inputs.push }}\`"
-          echo "- **Cache scope**: \`${{ inputs.cache-scope != '' && inputs.cache-scope || inputs.service-name }}\`"
+          echo "- **Cache**: \`registry (${{ inputs.artifactory-url }}/${{ inputs.google-project }}/artifacts/services/${{ inputs.service-name }}:buildcache)\`"
         } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Builds were running **0% cached** every time. The `build-and-push` action uses `type=gha` (GitHub Actions cache), and the repo's Actions cache is **12.6 GB across 205 entries** — over GitHub's **10 GB per-repo limit**. With ~20 services each exporting `mode=max` (~400–600 MB layer blobs), the cap is blown instantly and GitHub LRU-evicts caches before they're ever reused → `cache-from` finds nothing → full rebuild every run.

This switches the layer cache from GHA to a **registry-backed cache** (one `:buildcache` tag per service repo in Artifact Registry):
- no 10 GB cap, persists, and **shared across branches** (GHA cache is branch-scoped).
- `cache-to` only on **push** builds — PR/dependabot builds lack registry push creds, so they just **read** the shared cache.
- `image-manifest=true,oci-mediatypes=true` for Artifact Registry compatibility.

Also updates the description + build-summary line to say "registry" instead of "GitHub Actions cache".

Follow-up (not in this PR): the service Dockerfiles `ADD . .` the whole monorepo before `go build`, so the final compile layer still busts per-commit — scoping the copy would recover that layer too.

---

- Merge this PR into branch production: No
