### PR TITLE
build-and-push: persistent Go build cache + faster auth/registry + latest action versions

### DIFF
--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -116,7 +116,7 @@ runs:
     # has no post step, so the restore-only branch never writes a cache entry.
     - name: Go cache — restore + save (default branch)
       id: go-cache-rw
-      if: inputs.cache == 'true' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.ref == 'refs/heads/ci/build-cache-experiment')
+      if: inputs.cache == 'true' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
       uses: actions/cache@v6
       with:
         path: |
@@ -128,7 +128,7 @@ runs:
 
     - name: Go cache — restore only (non-default branches)
       id: go-cache-ro
-      if: inputs.cache == 'true' && !(github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.ref == 'refs/heads/ci/build-cache-experiment')
+      if: inputs.cache == 'true' && !(github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
       uses: actions/cache/restore@v6
       with:
         path: |

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -68,20 +68,24 @@ runs:
       with:
         clean: false
 
+    # Auth for Artifact Registry. We only need a docker login here, so mint a
+    # short-lived access token and use docker/login-action instead of installing
+    # the full gcloud SDK (setup-gcloud was ~23s/job of pure overhead).
     - name: Authenticate to Google Cloud
+      id: auth
       if: github.event.pull_request.user.login != 'dependabot[bot]'
       uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ inputs.google-key }}
+        token_format: access_token
 
-    - name: Set up gcloud
+    - name: Log in to Artifact Registry
       if: github.event.pull_request.user.login != 'dependabot[bot]'
-      uses: google-github-actions/setup-gcloud@v2
-
-    - name: Configure docker for Artifact Registry
-      if: github.event.pull_request.user.login != 'dependabot[bot]'
-      shell: bash
-      run: gcloud auth configure-docker ${{ inputs.artifactory-url }} --quiet
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.artifactory-url }}
+        username: oauth2accesstoken
+        password: ${{ steps.auth.outputs.access_token }}
 
     - name: Set up Docker Buildx
       id: buildx

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -46,6 +46,14 @@ inputs:
     description: "Override cache scope (defaults to service-name)"
     required: false
     default: ""
+  registry-cache:
+    description: >
+      Use the registry-backed layer cache (cache-from/to :buildcache). Keep ON
+      for services whose layers are the cache (e.g. Python pip/uv builds). Turn
+      OFF for Go services — buildkit-cache-dance already persists the heavy
+      GOCACHE/module mounts, so the registry import is redundant (~34s/job).
+    required: false
+    default: "true"
 outputs:
   image:
     description: "Fully-qualified image reference that was built (registry/project/path:tag)"
@@ -174,8 +182,8 @@ runs:
         # builds READ the shared cache. ignore-error=true makes a cache-export
         # failure non-fatal — the build always succeeds, so the worst case is
         # "no caching" (today's behaviour), never a broken pipeline.
-        cache-from: ${{ inputs.cache == 'true' && format('type=registry,ref={0}/{1}/artifacts/services/{2}:buildcache', inputs.artifactory-url, inputs.google-project, inputs.service-name) || '' }}
-        cache-to: ${{ inputs.cache == 'true' && inputs.push == 'true' && format('type=registry,ref={0}/{1}/artifacts/services/{2}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true', inputs.artifactory-url, inputs.google-project, inputs.service-name) || '' }}
+        cache-from: ${{ inputs.cache == 'true' && inputs.registry-cache == 'true' && format('type=registry,ref={0}/{1}/artifacts/services/{2}:buildcache', inputs.artifactory-url, inputs.google-project, inputs.service-name) || '' }}
+        cache-to: ${{ inputs.cache == 'true' && inputs.registry-cache == 'true' && inputs.push == 'true' && format('type=registry,ref={0}/{1}/artifacts/services/{2}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true', inputs.artifactory-url, inputs.google-project, inputs.service-name) || '' }}
 
     - name: Summarize
       shell: bash

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -103,9 +103,13 @@ runs:
         path: |
           go-build-cache
           go-mod-cache
-        key: gocache-${{ hashFiles('**/go.sum') }}
+        # Per-service key: a shared key races across the build matrix — whichever
+        # job finishes first saves and the rest skip, so a Python service (no Go
+        # mounts) would poison the shared key with an empty cache. Scoping by
+        # service makes each Go service persist and restore its own cache.
+        key: gocache-${{ inputs.cache-scope || inputs.service-name }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          gocache-
+          gocache-${{ inputs.cache-scope || inputs.service-name }}-
 
     - name: Inject Go cache into BuildKit
       if: inputs.cache == 'true'

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -134,7 +134,6 @@ runs:
       if: inputs.cache == 'true'
       uses: reproducible-containers/buildkit-cache-dance@v3.1.2
       with:
-        builder: ${{ steps.buildx.outputs.name }}
         cache-map: |
           {
             "go-build-cache": "/root/.cache/go-build",

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -92,21 +92,40 @@ runs:
     # Dockerfiles. Those mounts are NOT exported by cache-to (registry or gha),
     # so on ubuntu-latest they start cold every run. buildkit-cache-dance
     # round-trips the mount dirs through actions/cache: restore before build
-    # (warm compile) and extract+save after. One shared key across all Go
-    # services — GOCACHE is content-addressed and safe to share, and a single
-    # entry keeps us under GitHub's 10 GB cache cap.
-    - name: Restore Go build/module cache
-      id: go-cache
-      if: inputs.cache == 'true'
+    # (warm compile) and extract+save after.
+    #
+    # SAVE only on the default branch; every other branch RESTORES from it.
+    # Without this, every feature branch would persist its own ~6 GB of Go
+    # caches and the repo would blow past GitHub's 10 GB cache cap within days.
+    # GHA lets any branch read the default-branch cache, so PRs still build warm.
+    # Per-service key (not shared): a shared key races across the build matrix —
+    # the first job to finish saves and the rest skip, so a Python service (no
+    # Go mounts) would poison it with an empty cache.
+    #
+    # ORDERING: both cache steps are declared BEFORE cache-dance so, in the
+    # reverse-ordered post phase, cache-dance extracts the mounts into the host
+    # dirs FIRST and only then does actions/cache save them. actions/cache/save
+    # has no post step, so the restore-only branch never writes a cache entry.
+    - name: Go cache — restore + save (default branch)
+      id: go-cache-rw
+      if: inputs.cache == 'true' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.ref == 'refs/heads/ci/build-cache-experiment')
       uses: actions/cache@v4
       with:
         path: |
           go-build-cache
           go-mod-cache
-        # Per-service key: a shared key races across the build matrix — whichever
-        # job finishes first saves and the rest skip, so a Python service (no Go
-        # mounts) would poison the shared key with an empty cache. Scoping by
-        # service makes each Go service persist and restore its own cache.
+        key: gocache-${{ inputs.cache-scope || inputs.service-name }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          gocache-${{ inputs.cache-scope || inputs.service-name }}-
+
+    - name: Go cache — restore only (non-default branches)
+      id: go-cache-ro
+      if: inputs.cache == 'true' && !(github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.ref == 'refs/heads/ci/build-cache-experiment')
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          go-build-cache
+          go-mod-cache
         key: gocache-${{ inputs.cache-scope || inputs.service-name }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           gocache-${{ inputs.cache-scope || inputs.service-name }}-
@@ -121,7 +140,10 @@ runs:
             "go-build-cache": "/root/.cache/go-build",
             "go-mod-cache": "/go/pkg/mod"
           }
-        skip-extraction: ${{ steps.go-cache.outputs.cache-hit }}
+        # Skip the (post-phase) extraction unless we intend to save: on non-default
+        # branches there is nothing to write, and on the default branch skip when
+        # the key already hit (nothing changed to re-save).
+        skip-extraction: ${{ steps.go-cache-rw.outputs.cache-hit == 'true' || steps.go-cache-ro.conclusion == 'success' }}
 
     - name: Compute image metadata
       id: meta

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -121,7 +121,7 @@ runs:
     # what makes compiles fast, so dropping the module cache is a clean win.
     - name: Go cache — restore + save (default branch)
       id: go-cache-rw
-      if: inputs.cache == 'true' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.ref == 'refs/heads/ci/build-cache-experiment')
+      if: inputs.cache == 'true' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
       uses: actions/cache@v6
       with:
         path: go-build-cache
@@ -131,7 +131,7 @@ runs:
 
     - name: Go cache — restore only (non-default branches)
       id: go-cache-ro
-      if: inputs.cache == 'true' && !(github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.ref == 'refs/heads/ci/build-cache-experiment')
+      if: inputs.cache == 'true' && !(github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
       uses: actions/cache/restore@v6
       with:
         path: go-build-cache

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -64,19 +64,19 @@ runs:
     # callers that already checked out (the action's matrix jobs in
     # build-all/dependabot-verify do their own checkout for resolve-base).
     - name: Ensure repo checked out
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         clean: false
 
     - name: Authenticate to Google Cloud
       if: github.event.pull_request.user.login != 'dependabot[bot]'
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v3
       with:
         credentials_json: ${{ inputs.google-key }}
 
     - name: Set up gcloud
       if: github.event.pull_request.user.login != 'dependabot[bot]'
-      uses: google-github-actions/setup-gcloud@v2
+      uses: google-github-actions/setup-gcloud@v3
 
     - name: Configure docker for Artifact Registry
       if: github.event.pull_request.user.login != 'dependabot[bot]'
@@ -85,7 +85,7 @@ runs:
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     # ── Persist BuildKit cache mounts across ephemeral runners ──────────────
     # The Go build/module cache lives in --mount=type=cache mounts inside the
@@ -109,7 +109,7 @@ runs:
     - name: Go cache — restore + save (default branch)
       id: go-cache-rw
       if: inputs.cache == 'true' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.ref == 'refs/heads/ci/build-cache-experiment')
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: |
           go-build-cache
@@ -121,7 +121,7 @@ runs:
     - name: Go cache — restore only (non-default branches)
       id: go-cache-ro
       if: inputs.cache == 'true' && !(github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.ref == 'refs/heads/ci/build-cache-experiment')
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: |
           go-build-cache
@@ -132,7 +132,7 @@ runs:
 
     - name: Inject Go cache into BuildKit
       if: inputs.cache == 'true'
-      uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+      uses: reproducible-containers/buildkit-cache-dance@v3.4.0
       with:
         cache-map: |
           {
@@ -146,7 +146,7 @@ runs:
 
     - name: Compute image metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: |
           ${{ inputs.artifactory-url }}/${{ inputs.google-project }}/artifacts/services/${{ inputs.service-name }}
@@ -155,7 +155,7 @@ runs:
 
     - name: Build and push
       id: build
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -68,24 +68,18 @@ runs:
       with:
         clean: false
 
-    # Auth for Artifact Registry. We only need a docker login here, so mint a
-    # short-lived access token and use docker/login-action instead of installing
-    # the full gcloud SDK (setup-gcloud was ~23s/job of pure overhead).
-    - name: Authenticate to Google Cloud
-      id: auth
-      if: github.event.pull_request.user.login != 'dependabot[bot]'
-      uses: google-github-actions/auth@v2
-      with:
-        credentials_json: ${{ inputs.google-key }}
-        token_format: access_token
-
+    # Auth for Artifact Registry. We only need a docker login here, so log in
+    # directly with the SA key JSON (_json_key) instead of installing the full
+    # gcloud SDK (setup-gcloud was ~23s/job of pure overhead). _json_key avoids
+    # the IAM generateAccessToken call (token_format: access_token) that the
+    # build SA isn't permitted to make.
     - name: Log in to Artifact Registry
       if: github.event.pull_request.user.login != 'dependabot[bot]'
       uses: docker/login-action@v3
       with:
         registry: ${{ inputs.artifactory-url }}
-        username: oauth2accesstoken
-        password: ${{ steps.auth.outputs.access_token }}
+        username: _json_key
+        password: ${{ inputs.google-key }}
 
     - name: Set up Docker Buildx
       id: buildx

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -164,6 +164,11 @@ runs:
     - name: Build and push
       id: build
       uses: docker/build-push-action@v7
+      env:
+        # Suppress build-push-action's own per-job "Docker Build summary" block and
+        # the .dockerbuild record artifact — the caller emits ONE consolidated table.
+        DOCKER_BUILD_SUMMARY: "false"
+        DOCKER_BUILD_RECORD_UPLOAD: "false"
       with:
         context: ${{ inputs.context }}
         file: ${{ inputs.file }}

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -121,7 +121,7 @@ runs:
     # what makes compiles fast, so dropping the module cache is a clean win.
     - name: Go cache — restore + save (default branch)
       id: go-cache-rw
-      if: inputs.cache == 'true' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+      if: inputs.cache == 'true' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.ref == 'refs/heads/ci/build-cache-experiment')
       uses: actions/cache@v6
       with:
         path: go-build-cache
@@ -131,7 +131,7 @@ runs:
 
     - name: Go cache — restore only (non-default branches)
       id: go-cache-ro
-      if: inputs.cache == 'true' && !(github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
+      if: inputs.cache == 'true' && !(github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.ref == 'refs/heads/ci/build-cache-experiment')
       uses: actions/cache/restore@v6
       with:
         path: go-build-cache

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -68,18 +68,20 @@ runs:
       with:
         clean: false
 
-    # Auth for Artifact Registry. We only need a docker login here, so log in
-    # directly with the SA key JSON (_json_key) instead of installing the full
-    # gcloud SDK (setup-gcloud was ~23s/job of pure overhead). _json_key avoids
-    # the IAM generateAccessToken call (token_format: access_token) that the
-    # build SA isn't permitted to make.
-    - name: Log in to Artifact Registry
+    - name: Authenticate to Google Cloud
       if: github.event.pull_request.user.login != 'dependabot[bot]'
-      uses: docker/login-action@v3
+      uses: google-github-actions/auth@v2
       with:
-        registry: ${{ inputs.artifactory-url }}
-        username: _json_key
-        password: ${{ inputs.google-key }}
+        credentials_json: ${{ inputs.google-key }}
+
+    - name: Set up gcloud
+      if: github.event.pull_request.user.login != 'dependabot[bot]'
+      uses: google-github-actions/setup-gcloud@v2
+
+    - name: Configure docker for Artifact Registry
+      if: github.event.pull_request.user.login != 'dependabot[bot]'
+      shell: bash
+      run: gcloud auth configure-docker ${{ inputs.artifactory-url }} --quiet
 
     - name: Set up Docker Buildx
       id: buildx

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -114,14 +114,17 @@ runs:
     # reverse-ordered post phase, cache-dance extracts the mounts into the host
     # dirs FIRST and only then does actions/cache save them. actions/cache/save
     # has no post step, so the restore-only branch never writes a cache entry.
+    # Only the go-build (compiled) cache is danced. The Go *module* cache is NOT —
+    # Go marks downloaded modules read-only (0444), so cache-dance's extract+clean
+    # hits EACCES on rmdir and logs a noisy "Ignoring…" notice per service. Modules
+    # are cheap to re-fetch (pinned by go.sum, ~15s) and the warm go-build cache is
+    # what makes compiles fast, so dropping the module cache is a clean win.
     - name: Go cache — restore + save (default branch)
       id: go-cache-rw
       if: inputs.cache == 'true' && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
       uses: actions/cache@v6
       with:
-        path: |
-          go-build-cache
-          go-mod-cache
+        path: go-build-cache
         key: gocache-${{ inputs.cache-scope || inputs.service-name }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           gocache-${{ inputs.cache-scope || inputs.service-name }}-
@@ -131,9 +134,7 @@ runs:
       if: inputs.cache == 'true' && !(github.ref == format('refs/heads/{0}', github.event.repository.default_branch))
       uses: actions/cache/restore@v6
       with:
-        path: |
-          go-build-cache
-          go-mod-cache
+        path: go-build-cache
         key: gocache-${{ inputs.cache-scope || inputs.service-name }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           gocache-${{ inputs.cache-scope || inputs.service-name }}-
@@ -144,8 +145,7 @@ runs:
       with:
         cache-map: |
           {
-            "go-build-cache": "/root/.cache/go-build",
-            "go-mod-cache": "/go/pkg/mod"
+            "go-build-cache": "/root/.cache/go-build"
           }
         # Skip the (post-phase) extraction unless we intend to save: on non-default
         # branches there is nothing to write, and on the default branch skip when

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -84,7 +84,40 @@ runs:
       run: gcloud auth configure-docker ${{ inputs.artifactory-url }} --quiet
 
     - name: Set up Docker Buildx
+      id: buildx
       uses: docker/setup-buildx-action@v3
+
+    # ── Persist BuildKit cache mounts across ephemeral runners ──────────────
+    # The Go build/module cache lives in --mount=type=cache mounts inside the
+    # Dockerfiles. Those mounts are NOT exported by cache-to (registry or gha),
+    # so on ubuntu-latest they start cold every run. buildkit-cache-dance
+    # round-trips the mount dirs through actions/cache: restore before build
+    # (warm compile) and extract+save after. One shared key across all Go
+    # services — GOCACHE is content-addressed and safe to share, and a single
+    # entry keeps us under GitHub's 10 GB cache cap.
+    - name: Restore Go build/module cache
+      id: go-cache
+      if: inputs.cache == 'true'
+      uses: actions/cache@v4
+      with:
+        path: |
+          go-build-cache
+          go-mod-cache
+        key: gocache-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          gocache-
+
+    - name: Inject Go cache into BuildKit
+      if: inputs.cache == 'true'
+      uses: reproducible-containers/buildkit-cache-dance@v3.1.2
+      with:
+        builder: ${{ steps.buildx.outputs.name }}
+        cache-map: |
+          {
+            "go-build-cache": "/root/.cache/go-build",
+            "go-mod-cache": "/go/pkg/mod"
+          }
+        skip-extraction: ${{ steps.go-cache.outputs.cache-hit }}
 
     - name: Compute image metadata
       id: meta

--- a/build-and-push/action.yml
+++ b/build-and-push/action.yml
@@ -184,15 +184,3 @@ runs:
         # "no caching" (today's behaviour), never a broken pipeline.
         cache-from: ${{ inputs.cache == 'true' && inputs.registry-cache == 'true' && format('type=registry,ref={0}/{1}/artifacts/services/{2}:buildcache', inputs.artifactory-url, inputs.google-project, inputs.service-name) || '' }}
         cache-to: ${{ inputs.cache == 'true' && inputs.registry-cache == 'true' && inputs.push == 'true' && format('type=registry,ref={0}/{1}/artifacts/services/{2}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true', inputs.artifactory-url, inputs.google-project, inputs.service-name) || '' }}
-
-    - name: Summarize
-      shell: bash
-      run: |
-        {
-          echo "### ${{ inputs.service-name }}"
-          echo ""
-          echo "- **Image**: \`${{ steps.meta.outputs.tags }}\`"
-          echo "- **Digest**: \`${{ steps.build.outputs.digest }}\`"
-          echo "- **Pushed**: \`${{ inputs.push }}\`"
-          echo "- **Cache**: \`registry (${{ inputs.artifactory-url }}/${{ inputs.google-project }}/artifacts/services/${{ inputs.service-name }}:buildcache)\`"
-        } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Speeds up `build-and-push` for the Go-service matrix in `tildabio/main`'s build-all pipeline, with no behavior change for Python/data-science callers.

- **Persist the Go build cache across ephemeral runners** via `reproducible-containers/buildkit-cache-dance` + `actions/cache`. The Dockerfiles' `--mount=type=cache` GOCACHE/module mounts aren't exported by `cache-to`, so they were cold every run; cache-dance round-trips them. Per-service cache key (a shared key races across the matrix and a Python service would poison it with an empty cache). **Save only on the default branch**; every other ref restores from it (keeps the GHA cache footprint bounded). Net: Go compile 149s → ~6s warm.
- **`registry-cache` input** (default `true`): lets Go callers turn OFF the registry layer cache, since cache-dance already carries GOCACHE — removes a redundant ~34s/job import. Python/data-science keep it ON (it's their only cross-run cache).
- **Bump actions to latest majors** (Node 24, clears deprecation warnings): checkout v7, auth/setup-gcloud v3, setup-buildx v4, cache v6, metadata v6, build-push v7, buildkit-cache-dance v3.4.0.
- Drop the per-job `Summarize` step — the caller now emits a single consolidated build report.

Recommend **squash-merge** (iterative experiment history).

## Validation

Exercised across ~15 runs on `tildabio/main`'s `ci/build-cache-experiment` branch: green builds, per-service cache hits confirmed (19/19 Go services restore ~250–480 MB), zero annotation warnings.