### PR TITLE
feat(cherry-pick-pr): credit original author, use bot committer + app token

### DIFF
--- a/cherry-pick-pr/action.yml
+++ b/cherry-pick-pr/action.yml
@@ -10,8 +10,24 @@ inputs:
     description: 'Branch to cherry-pick into (e.g., production, master, staging)'
     required: true
   github-token:
-    description: 'GitHub token for API operations (use secrets.GH_PAT or secrets.GITHUB_TOKEN)'
+    description: >
+      GitHub token for API operations. Prefer a GitHub App installation token
+      (e.g. via actions/create-github-app-token) so the cherry-pick PR and its
+      commits are attributed to a bot identity rather than a person's PAT.
     required: true
+  committer:
+    description: >
+      Committer identity for the cherry-pick commit, as `Display Name <email>`.
+      Defaults to the GitHub Actions bot so automation is not attributed to a person.
+    required: false
+    default: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+  author:
+    description: >
+      Author identity for the cherry-pick commit, as `Display Name <email>`.
+      Defaults to the original PR author so contribution analytics credit the
+      developer who wrote the change rather than whoever merged it.
+    required: false
+    default: '${{ github.event.pull_request.user.login }} <${{ github.event.pull_request.user.id }}+${{ github.event.pull_request.user.login }}@users.noreply.github.com>'
   pr-body:
     description: 'The PR body text to check for merge decision'
     required: true
@@ -137,6 +153,8 @@ runs:
       uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
       with:
         token: ${{ inputs.github-token }}
+        committer: ${{ inputs.committer }}
+        author: ${{ inputs.author }}
         branch: ${{ inputs.target-branch }}
         cherry-pick-branch: ${{ inputs.cherry-pick-branch-prefix }}${{ github.event.pull_request.head.ref }}
         body: ${{ inputs.cherry-pick-pr-body }}


### PR DESCRIPTION
## Summary

The `cherry-pick-pr` action delegates to `carloscastrojumo/github-cherry-pick-action@v1.0.9` but never sets `committer`/`author`. With the upstream defaults, every cherry-picked commit is **authored by whoever merged** (`github.actor`) and the cherry-pick PR is **opened by the token owner** (typically a personal `GH_PAT`). The result: contribution analytics credit the merger/PAT-owner instead of the developer who actually wrote the change.

This PR makes attribution correct and bot-driven, without breaking existing callers.

## Changes

- Add optional `committer` / `author` inputs, passed through to the underlying action.
  - `author` defaults to the **original PR author** (`github.event.pull_request.user`) → analytics credit the real developer.
  - `committer` defaults to **github-actions[bot]** → automation isn't attributed to a person.
- Update the `github-token` description to recommend a **GitHub App installation token** over a personal PAT, so the cherry-pick PR/comments are made by a bot identity.

All new inputs are optional with sensible defaults, so existing workflows keep working; they simply get correct attribution automatically.

## Follow-up

A companion cleopatra PR swaps the merge workflows from `secrets.GH_PAT` to a GitHub App token (app 126391, already used by other workflows there).