### PR TITLE
ci: add no-op Required Check for Vanta merge gating

### DIFF
--- a/.github/workflows/required-check.yaml
+++ b/.github/workflows/required-check.yaml
@@ -1,0 +1,24 @@
+name: Required Check
+
+# No-op status check that always succeeds. The actions repo has no build/test
+# pipeline of its own, but Vanta's change-management control requires a passing
+# status check before anything merges to the default branch. This gives branch
+# protection a stable check context ("Required Check") to require.
+#
+# Mark it required: Settings -> Branches -> main -> Require status checks ->
+# add "Required Check".
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  required-check:
+    name: Required Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pass
+        run: echo "✅ Required check passed."


### PR DESCRIPTION
## Summary

The actions repo has **no `.github/workflows` at all**, so there's no status check gating merges to `main`. Vanta's change-management control wants a passing check before anything merges to the default branch. This adds a minimal **always-success** check so branch protection has a stable context to require.

- Triggers on `pull_request` to `main`.
- Single job named **`Required Check`** that just echoes success — no build/test logic (this repo only holds composite actions, nothing to build).
- `permissions: contents: read` only.

## Follow-up (manual, by an admin)

After merge, make it required: **Settings → Branches → `main` → Require status checks to pass → add `Required Check`**. The workflow has to land on `main` once before the check name appears in that list.

This mirrors the intent of the required gate we use elsewhere (e.g. cleopatra's `Validation Summary`), minus the actual validation since there's nothing to validate here.